### PR TITLE
many: port from varlink & varlink_parser to zlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,14 +58,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
+name = "async-broadcast"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -237,13 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -282,6 +312,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -486,6 +522,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +614,25 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -706,6 +782,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -1106,15 +1188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,33 +1389,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "peg"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
-dependencies = [
- "peg-macros",
- "peg-runtime",
-]
-
-[[package]]
-name = "peg-macros"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
-dependencies = [
- "peg-runtime",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "peg-runtime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1391,6 +1443,20 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2131,6 +2197,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2167,6 +2234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2255,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2274,17 +2366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "uds_windows"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,23 +2447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "varlink"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c4fb29c00c9a3aedd6352a55611d9bfca85787ac7ec24d085aa2ddab756662"
-dependencies = [
- "async-trait",
- "libc",
- "serde",
- "serde_derive",
- "serde_json",
- "tempfile",
- "tokio",
- "uds_windows",
- "winapi",
-]
-
-[[package]]
 name = "varlink-http-bridge"
 version = "0.1.0"
 dependencies = [
@@ -2400,6 +2464,7 @@ dependencies = [
  "reqwest",
  "rustix",
  "scopeguard",
+ "serde",
  "serde_json",
  "signal-hook",
  "ssh-key",
@@ -2412,19 +2477,7 @@ dependencies = [
  "tower",
  "tungstenite",
  "ureq",
- "varlink",
- "varlink_parser",
-]
-
-[[package]]
-name = "varlink_parser"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c5eb26ddfee2263eace3f39e3504da7e624bfc33f1facebd2d7227bbb26fb1"
-dependencies = [
- "colored",
- "peg",
- "thiserror",
+ "zlink",
 ]
 
 [[package]]
@@ -2614,20 +2667,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2641,42 +2685,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2686,21 +2708,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2710,21 +2720,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2734,21 +2732,9 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2758,15 +2744,15 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wit-bindgen"
@@ -2963,6 +2949,74 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zlink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5ad065e2697e98764f2738793904ff0aaa672707d0ee1592dfb4c47800962a"
+dependencies = [
+ "zlink-smol",
+ "zlink-tokio",
+]
+
+[[package]]
+name = "zlink-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae6561573e9996c2c26bf1c723b137a99c2d571a3276bd8f4ac52bfa44b3f2c"
+dependencies = [
+ "futures-util",
+ "itoa",
+ "libc",
+ "pin-project-lite",
+ "rustix",
+ "ryu",
+ "serde",
+ "serde_json",
+ "tracing",
+ "winnow",
+ "zlink-macros",
+]
+
+[[package]]
+name = "zlink-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4219a5aadc4844073d134e27fd52228933a462fbd07fe51ac5df8393f08168a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zlink-smol"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befa02505904ee15f6721fdae1b6473d59649049c1f1810175fb7205a4dca82a"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-io",
+ "futures-lite",
+ "futures-util",
+ "pin-project-lite",
+ "zlink-core",
+]
+
+[[package]]
+name = "zlink-tokio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378110fc4fad5fa9359251eb830d87993efcca44245f538a552cf26001649378"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+ "zlink-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ anyhow = "1.0.100"
 axum = { version = "0.8.8", features = ["ws"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }
-varlink = { version = "13.0", features = ["tokio"] }
-varlink_parser = "6.0.0"
+# not using default features as we don't need service/server/introspection
+zlink = { version = "0.4", default-features = false, features = ["tokio", "proxy", "idl-parse", "tracing"] }
+serde = { version = "1", features = ["derive"] }
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["color", "humantime"] }
 # not using clap here as its relatively heavy (500kb-1Mb depending on cfg)

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use axum::{
 use listenfd::ListenFd;
 use log::{debug, error, warn};
 use regex_lite::Regex;
+use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -22,7 +23,7 @@ use std::sync::{Arc, LazyLock};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixStream};
 use tokio::signal;
-use varlink_parser::IDL;
+use zlink::varlink_service::Proxy;
 
 #[cfg(feature = "sshauth")]
 mod auth_ssh;
@@ -65,19 +66,22 @@ impl IntoResponse for AppError {
     }
 }
 
-impl From<varlink::Error> for AppError {
-    fn from(e: varlink::Error) -> Self {
-        use varlink::error::ErrorKind::{
-            ConnectionClosed, InvalidParameter, Io, MethodNotFound, MethodNotImplemented,
-        };
-        let status = match e.kind() {
-            InvalidParameter { .. } => StatusCode::BAD_REQUEST,
-            MethodNotFound { .. } => StatusCode::NOT_FOUND,
-            MethodNotImplemented { .. } => StatusCode::NOT_IMPLEMENTED,
-            // TODO: implement something like NotExists or NotFound in the upstream
-            // varlink crate as IO error is extremly generic. Also add details upstream
-            // to the error string (like what socket)
-            ConnectionClosed | Io { .. } => StatusCode::BAD_GATEWAY,
+impl From<zlink::Error> for AppError {
+    fn from(e: zlink::Error) -> Self {
+        use zlink::varlink_service;
+        let status = match &e {
+            zlink::Error::SocketRead
+            | zlink::Error::SocketWrite
+            | zlink::Error::UnexpectedEof
+            | zlink::Error::Io(..) => StatusCode::BAD_GATEWAY,
+            zlink::Error::VarlinkService(owned) => match owned.inner() {
+                varlink_service::Error::InvalidParameter { .. }
+                | varlink_service::Error::ExpectedMore => StatusCode::BAD_REQUEST,
+                varlink_service::Error::MethodNotFound { .. }
+                | varlink_service::Error::InterfaceNotFound { .. } => StatusCode::NOT_FOUND,
+                varlink_service::Error::MethodNotImplemented { .. } => StatusCode::NOT_IMPLEMENTED,
+                varlink_service::Error::PermissionDenied => StatusCode::FORBIDDEN,
+            },
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         Self {
@@ -92,6 +96,54 @@ impl From<std::io::Error> for AppError {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             message: e.to_string(),
+        }
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Method call with dynamic method name and parameters for the POST `/call/{method}` route.
+#[derive(Debug, Serialize)]
+struct DynMethod<'m> {
+    method: &'m str,
+    parameters: Option<&'m HashMap<String, Value>>,
+}
+
+/// Successful reply parameters from a dynamic varlink call.
+#[derive(Debug, Default, serde::Deserialize)]
+struct DynReply<'r>(#[serde(borrow)] Option<HashMap<&'r str, Value>>);
+
+impl IntoResponse for DynReply<'_> {
+    fn into_response(self) -> Response {
+        axum::Json(self.0).into_response()
+    }
+}
+
+/// Error reply from a dynamic varlink call (non-standard errors only; standard
+/// `org.varlink.service.*` errors are caught earlier by zlink).
+#[derive(Debug, serde::Deserialize)]
+struct DynReplyError<'e> {
+    error: &'e str,
+    #[serde(default)]
+    parameters: Option<HashMap<&'e str, Value>>,
+}
+
+impl From<DynReplyError<'_>> for AppError {
+    fn from(e: DynReplyError<'_>) -> Self {
+        let message = match e.parameters {
+            Some(params) => format!("{}: {params:?}", e.error),
+            None => e.error.to_string(),
+        };
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message,
         }
     }
 }
@@ -145,14 +197,14 @@ impl VarlinkSockets {
 
         match self {
             VarlinkSockets::SocketDir { dirfd } => {
-                Ok(format!("unix:/proc/self/fd/{}/{name}", dirfd.as_raw_fd()))
+                Ok(format!("/proc/self/fd/{}/{name}", dirfd.as_raw_fd()))
             }
             VarlinkSockets::SingleSocket {
                 dirfd,
                 name: expected,
             } => {
                 if name == expected {
-                    Ok(format!("unix:/proc/self/fd/{}/{name}", dirfd.as_raw_fd()))
+                    Ok(format!("/proc/self/fd/{}/{name}", dirfd.as_raw_fd()))
                 } else {
                     Err(AppError::bad_gateway(format!(
                         "socket '{name}' not available (only '{expected}' is available)"
@@ -195,11 +247,11 @@ impl VarlinkSockets {
 async fn get_varlink_connection_with_validate_socket(
     socket: &str,
     state: &AppState,
-) -> Result<Arc<varlink::AsyncConnection>, AppError> {
+) -> Result<zlink::unix::Connection, AppError> {
     let varlink_socket_path = state.varlink_sockets.resolve_socket_with_validate(socket)?;
     debug!("Creating varlink connection for: {varlink_socket_path}");
 
-    let connection = varlink::AsyncConnection::with_address(varlink_socket_path).await?;
+    let connection = zlink::unix::connect(&varlink_socket_path).await?;
     Ok(connection)
 }
 
@@ -376,15 +428,13 @@ async fn route_socket_get(
     State(state): State<AppState>,
 ) -> Result<axum::Json<Value>, AppError> {
     debug!("GET socket: {socket}");
-    let connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
+    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
 
-    let mut call = varlink::AsyncMethodCall::<Value, Value, varlink::Error>::new(
-        connection,
-        "org.varlink.service.GetInfo",
-        Value::Null,
-    );
-    let reply = call.call().await?;
-    Ok(axum::Json(reply))
+    let info = connection
+        .get_info()
+        .await?
+        .map_err(|e| AppError::bad_gateway(format!("service error: {e}")))?;
+    Ok(axum::Json(serde_json::to_value(info)?))
 }
 
 async fn route_socket_interface_get(
@@ -392,32 +442,27 @@ async fn route_socket_interface_get(
     State(state): State<AppState>,
 ) -> Result<axum::Json<Value>, AppError> {
     debug!("GET socket: {socket}, interface: {interface}");
-    let connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
+    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
 
-    let mut call = varlink::AsyncMethodCall::<Value, Value, varlink::Error>::new(
-        connection,
-        "org.varlink.service.GetInterfaceDescription",
-        json!({"interface": interface}),
-    );
-    let reply = call.call().await?;
+    let description = connection
+        .get_interface_description(&interface)
+        .await?
+        .map_err(|e| AppError::bad_gateway(format!("service error: {e}")))?;
 
-    let description = reply
-        .get("description")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AppError::bad_gateway("upstream response missing 'description' field"))?;
-
-    let iface = IDL::try_from(description)
+    let iface = description
+        .parse()
         .map_err(|e| AppError::bad_gateway(format!("upstream IDL parse error: {e}")))?;
 
-    Ok(axum::Json(json!({"method_names": iface.method_keys})))
+    let method_names: Vec<&str> = iface.methods().map(zlink::idl::Method::name).collect();
+    Ok(axum::Json(json!({"method_names": method_names})))
 }
 
 async fn route_call_post(
     Path(method): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
-    axum::Json(call_args): axum::Json<Value>,
-) -> Result<axum::Json<Value>, AppError> {
+    axum::Json(call_args): axum::Json<HashMap<String, Value>>,
+) -> Result<Response, AppError> {
     debug!("POST call for method: {method}, params: {params:#?}");
 
     let socket = if let Some(socket) = params.get("socket") {
@@ -434,14 +479,18 @@ async fn route_call_post(
             .to_string()
     };
 
-    let connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
+    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
 
-    let mut call = varlink::AsyncMethodCall::<Value, Value, varlink::Error>::new(
-        connection, method, call_args,
-    );
-    let reply = call.call().await?;
-
-    Ok(axum::Json(reply))
+    let call = zlink::Call::new(DynMethod {
+        method: &method,
+        parameters: Some(&call_args),
+    });
+    connection
+        .call_method::<_, DynReply<'_>, DynReplyError<'_>>(&call, vec![])
+        .await?
+        .0
+        .map(|r| r.into_parameters().unwrap_or_default().into_response())
+        .map_err(Into::into)
 }
 
 async fn route_ws(
@@ -449,13 +498,12 @@ async fn route_ws(
     State(state): State<AppState>,
     ws: WebSocketUpgrade,
 ) -> Result<Response, AppError> {
-    let varlink_addr = state
+    let unix_path = state
         .varlink_sockets
         .resolve_socket_with_validate(&varlink_socket)?;
-    let unix_path = varlink_addr.strip_prefix("unix:").unwrap_or(&varlink_addr);
 
-    // Connect eagerly so connection failures return proper HTTP errors
-    let varlink_stream = UnixStream::connect(unix_path)
+    // Connect eagerly so connection failures return proper HTTP errors.
+    let varlink_stream = UnixStream::connect(&unix_path)
         .await
         .map_err(|e| AppError::bad_gateway(format!("cannot connect to {unix_path}: {e}")))?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -261,8 +261,11 @@ async fn test_error_unknown_varlink_address() {
 
     assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
     let body: Value = res.json().await.expect("error body invalid");
-    // TODO: see comment in impl From<varlink::Error>, would be great to improve this upstream
-    assert_eq!(body["error"], "IO error");
+    let error_msg = body["error"].as_str().expect("error field missing");
+    assert!(
+        error_msg.starts_with("I/O error:"),
+        "expected I/O error message, got: {error_msg}"
+    );
 }
 
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
@@ -286,7 +289,7 @@ async fn test_error_404_for_missing_method() {
 
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     let body: Value = res.json().await.expect("error body invalid");
-    assert_eq!(body["error"], "Method not found: 'com.missing.Call'");
+    assert_eq!(body["error"], "Method not found: com.missing.Call");
 }
 
 #[test_with::path(/run/systemd)]


### PR DESCRIPTION
Replace `varlink` and `varlink_parser` crates with `zlink`, the modern async-first replacement.
    
Key improvements:
    
1. IDL parsing is ~3.8× faster (1.7 µs vs 6.4 µs, see benchmarks).
    
1. Typed Proxy trait — `get_info()` and `get_interface_description()` as first-class methods on Connection, replacing manual       AsyncMethodCall construction with string-based method names.

1. No Arc wrapping — zlink's Connection uses `&mut self` directly, removing the need for Arc<AsyncConnection>.
    
1. Better error separation — transport errors (SocketRead, Io, etc.) vs application errors (VarlinkService) are cleanly separated, enabling more precise HTTP status mapping:
  - PermissionDenied → 403 (new)
  - InterfaceNotFound → 404 (new)
  - ExpectedMore → 400 (new)
    
1. Socket paths no longer need the `unix:` prefix — zlink's `unix::connect()` takes plain filesystem paths.
    
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---

Notes:

1. Yes, I totally vibe-coded this  but this kind of work is really what these tools are good for and very boring to work on. I did go through the code and everything looked good to me. Please don't punish me for being honest about this. :pray: 
2. The benchmarks were mainly written to show how zlink is faster but I can remove them from this branch, if you like.