### PR TITLE
bridge: support --more via json-seq and pipelining in plain http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,9 +1149,9 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -2437,9 +2459,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2450,8 +2472,10 @@ name = "varlink-http-bridge"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum",
  "env_logger",
+ "futures-core",
  "futures-util",
  "gethostname",
  "indoc",
@@ -2799,18 +2823,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ sshauth = ["dep:ssh-key", "dep:sshauth", "dep:ureq", "dep:tempfile"]
 
 [dependencies]
 anyhow = "1.0.100"
+async-stream = "0.3"
 axum = { version = "0.8.8", features = ["ws"] }
+futures-core = "0.3"
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }
 # not using default features as we don't need service/server/introspection

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ $ curl -s -X POST http://localhost:1031/call/org.varlink.service.GetInfo?socket=
   "version": "259 (259-1)"
 }
 
+# streaming methods use Accept: application/json-seq (RFC 7464)
+$ curl -s -H "Accept: application/json-seq" -H "Content-Type: application/json" \
+    http://localhost:1031/call/io.systemd.UserDatabase.GetUserRecord \
+    -d '{"service":"io.systemd.Multiplexer"}' | jq --seq
+
 ```
 
 ### Example (varlinkctl transparent bridge mode)

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 use anyhow::{Context, bail};
+use async_stream::stream;
 use axum::{
     Router,
+    body::Body,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
     extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State},
     http::StatusCode,
@@ -23,7 +25,7 @@ use std::sync::{Arc, LazyLock};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixStream};
 use tokio::signal;
-use zlink::{Reply, varlink_service::Proxy};
+use zlink::varlink_service::Proxy;
 
 #[cfg(feature = "sshauth")]
 mod auth_ssh;
@@ -520,10 +522,51 @@ async fn route_socket_interface_get(
     Ok(axum::Json(json!({"method_names": method_names})))
 }
 
+/// Stream varlink `more` replies as a JSON text sequence (RFC 7464).
+///
+/// Each record is RS (0x1E) + JSON + LF.  The content-type is
+/// `application/json-seq`.
+fn varlink_call_to_jsonseq(mut conn: zlink::unix::Connection) -> Response {
+    let stream = stream! {
+        loop {
+            match conn.receive_reply::<Value, DynReplyError>().await {
+                Ok((reply, _fds)) => {
+                    let continues = reply.as_ref().is_ok_and(|r| r.continues().unwrap_or(false));
+                    let json_str = match reply {
+                        Ok(r) => serde_json::to_string(&r.into_parameters()).unwrap_or_default(),
+                        Err(e) => json!({"error": e.error, "parameters": e.parameters}).to_string(),
+                    };
+                    yield Ok::<_, std::convert::Infallible>(
+                        format!("\x1e{json_str}\n"),
+                    );
+                    if !continues {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let error_json = json!({"error": e.to_string()});
+                    yield Ok(format!("\x1e{error_json}\n"));
+                    break;
+                }
+            }
+        }
+    };
+    Response::builder()
+        .header("Content-Type", "application/json-seq")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+/// Call a varlink method.
+///
+/// - Default: single JSON response via varlink `call`
+/// - `Accept: application/json-seq`: stream replies via varlink `more`
+///   as a JSON text sequence (RFC 7464)
 async fn route_call_post(
     Path(method): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     axum::Json(call_args): axum::Json<HashMap<String, Value>>,
 ) -> Result<Response, AppError> {
     debug!("POST call for method: {method}, params: {params:#?}");
@@ -544,16 +587,29 @@ async fn route_call_post(
 
     let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
 
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
     let method_call = DynMethod {
         method: &method,
         parameters: Some(&call_args),
     };
-    connection
-        .call_method(&method_call.into(), vec![])
-        .await?
-        .0
-        .map(|r: Reply<DynReply>| r.into_parameters().unwrap_or_default().into_response())
-        .map_err(|e: DynReplyError| e.into())
+
+    if accept.contains("application/json-seq") {
+        connection
+            .send_call(&zlink::Call::new(&method_call).set_more(true), vec![])
+            .await?;
+        Ok(varlink_call_to_jsonseq(connection))
+    } else {
+        connection
+            .call_method::<_, DynReply, DynReplyError>(&method_call.into(), vec![])
+            .await?
+            .0
+            .map(|r| r.into_parameters().unwrap_or_default().into_response())
+            .map_err(AppError::from)
+    }
 }
 
 async fn route_ws(

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -5,12 +5,14 @@ use async_stream::stream;
 use axum::{
     Router,
     body::Body,
+    extract::connect_info::Connected,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
     extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{get, post},
+    serve::IncomingStream,
 };
 use listenfd::ListenFd;
 use log::{debug, error, warn};
@@ -246,14 +248,54 @@ impl VarlinkSockets {
     }
 }
 
-async fn get_varlink_connection_with_validate_socket(
+type VarlinkConns = HashMap<String, Arc<tokio::sync::Mutex<zlink::unix::Connection>>>;
+
+/// Per-HTTP-connection cache of varlink unix socket connections.
+///
+/// Created once when an HTTP connection is accepted (via [`Connected`])
+/// and shared across all requests on that connection.  When the HTTP
+/// connection closes the cache is dropped, closing the varlink sockets.
+///
+/// Also carries the optional TLS channel binding for SSH-based auth.
+#[derive(Clone)]
+struct VarlinkConnCache {
+    conns: Arc<tokio::sync::Mutex<VarlinkConns>>,
+    tls_channel_binding: Option<String>,
+}
+
+impl VarlinkConnCache {
+    fn new(tls_channel_binding: Option<String>) -> Self {
+        Self {
+            conns: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            tls_channel_binding,
+        }
+    }
+}
+
+impl Connected<IncomingStream<'_, PlainListener>> for VarlinkConnCache {
+    fn connect_info(_: IncomingStream<'_, PlainListener>) -> Self {
+        Self::new(None)
+    }
+}
+
+async fn get_varlink_connection(
     socket: &str,
     state: &AppState,
-) -> Result<zlink::unix::Connection, AppError> {
+    conn_cache: &VarlinkConnCache,
+) -> Result<Arc<tokio::sync::Mutex<zlink::unix::Connection>>, AppError> {
     let varlink_socket_path = state.varlink_sockets.resolve_socket_with_validate(socket)?;
-    debug!("Creating varlink connection for: {varlink_socket_path}");
 
-    let connection = zlink::unix::connect(&varlink_socket_path).await?;
+    let mut cache = conn_cache.conns.lock().await;
+    if let Some(conn) = cache.get(socket) {
+        debug!("Reusing varlink connection for: {varlink_socket_path}");
+        return Ok(conn.clone());
+    }
+
+    debug!("Creating varlink connection for: {varlink_socket_path}");
+    let connection = Arc::new(tokio::sync::Mutex::new(
+        zlink::unix::connect(&varlink_socket_path).await?,
+    ));
+    cache.insert(socket.to_string(), connection.clone());
     Ok(connection)
 }
 
@@ -328,21 +370,11 @@ impl axum::serve::Listener for PlainListener {
     }
 }
 
-#[derive(Clone)]
-struct TlsConnectionInfo {
-    tls_channel_binding: String,
-}
-
-use axum::extract::connect_info::Connected;
-use axum::serve::IncomingStream;
-
-impl Connected<IncomingStream<'_, TlsListener>> for TlsConnectionInfo {
+impl Connected<IncomingStream<'_, TlsListener>> for VarlinkConnCache {
     fn connect_info(target: IncomingStream<'_, TlsListener>) -> Self {
         let tls_channel_binding =
             varlink_http_bridge::export_tls_channel_binding(target.io().ssl());
-        TlsConnectionInfo {
-            tls_channel_binding,
-        }
+        Self::new(Some(tls_channel_binding))
     }
 }
 
@@ -445,8 +477,8 @@ async fn auth_middleware(
 
     let tls_channel_binding: Option<String> = request
         .extensions()
-        .get::<ConnectInfo<TlsConnectionInfo>>()
-        .map(|ci| ci.0.tls_channel_binding.clone());
+        .get::<ConnectInfo<VarlinkConnCache>>()
+        .and_then(|ci| ci.0.tls_channel_binding.clone());
 
     let method = request.method().as_str().to_string();
     let path = request
@@ -489,11 +521,13 @@ async fn route_sockets_get(State(state): State<AppState>) -> Result<axum::Json<V
 }
 
 async fn route_socket_get(
+    ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
     Path(socket): Path<String>,
     State(state): State<AppState>,
 ) -> Result<axum::Json<Value>, AppError> {
     debug!("GET socket: {socket}");
-    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
+    let conn_arc = get_varlink_connection(&socket, &state, &conn_cache).await?;
+    let mut connection = conn_arc.lock().await;
 
     let info = connection
         .get_info()
@@ -503,11 +537,13 @@ async fn route_socket_get(
 }
 
 async fn route_socket_interface_get(
+    ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
     Path((socket, interface)): Path<(String, String)>,
     State(state): State<AppState>,
 ) -> Result<axum::Json<Value>, AppError> {
     debug!("GET socket: {socket}, interface: {interface}");
-    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
+    let conn_arc = get_varlink_connection(&socket, &state, &conn_cache).await?;
+    let mut connection = conn_arc.lock().await;
 
     let description = connection
         .get_interface_description(&interface)
@@ -526,7 +562,9 @@ async fn route_socket_interface_get(
 ///
 /// Each record is RS (0x1E) + JSON + LF.  The content-type is
 /// `application/json-seq`.
-fn varlink_call_to_jsonseq(mut conn: zlink::unix::Connection) -> Response {
+fn varlink_call_to_jsonseq(
+    mut conn: tokio::sync::OwnedMutexGuard<zlink::unix::Connection>,
+) -> Response {
     let stream = stream! {
         loop {
             match conn.receive_reply::<Value, DynReplyError>().await {
@@ -563,6 +601,7 @@ fn varlink_call_to_jsonseq(mut conn: zlink::unix::Connection) -> Response {
 /// - `Accept: application/json-seq`: stream replies via varlink `more`
 ///   as a JSON text sequence (RFC 7464)
 async fn route_call_post(
+    ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
     Path(method): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
@@ -585,8 +624,6 @@ async fn route_call_post(
             .to_string()
     };
 
-    let mut connection = get_varlink_connection_with_validate_socket(&socket, &state).await?;
-
     let accept = headers
         .get(axum::http::header::ACCEPT)
         .and_then(|v| v.to_str().ok())
@@ -597,6 +634,8 @@ async fn route_call_post(
         parameters: Some(&call_args),
     };
 
+    let conn_arc = get_varlink_connection(&socket, &state, &conn_cache).await?;
+    let mut connection = conn_arc.lock_owned().await;
     if accept.contains("application/json-seq") {
         connection
             .send_call(&zlink::Call::new(&method_call).set_more(true), vec![])
@@ -800,21 +839,19 @@ async fn run_server(
     authenticators: Vec<Box<dyn Authenticator>>,
 ) -> anyhow::Result<()> {
     let app = create_router(varlink_sockets_path, authenticators)?;
+    let make_svc = app.into_make_service_with_connect_info::<VarlinkConnCache>();
 
     if let Some(acceptor) = tls_acceptor {
         let tls_listener = TlsListener {
             inner: listener,
             acceptor,
         };
-        axum::serve(
-            tls_listener,
-            app.into_make_service_with_connect_info::<TlsConnectionInfo>(),
-        )
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+        axum::serve(tls_listener, make_svc)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
     } else {
         let plain_listener = PlainListener { inner: listener };
-        axum::serve(plain_listener, app)
+        axum::serve(plain_listener, make_svc)
             .with_graceful_shutdown(shutdown_signal())
             .await?;
     }

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -15,7 +15,7 @@ use axum::{
     serve::IncomingStream,
 };
 use listenfd::ListenFd;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -273,7 +273,8 @@ impl VarlinkConnCache {
 }
 
 impl Connected<IncomingStream<'_, PlainListener>> for VarlinkConnCache {
-    fn connect_info(_: IncomingStream<'_, PlainListener>) -> Self {
+    fn connect_info(target: IncomingStream<'_, PlainListener>) -> Self {
+        info!("New connection from {}", target.remote_addr());
         Self::new(None)
     }
 }
@@ -316,6 +317,28 @@ async fn accept_and_configure(
     }
 }
 
+fn format_x509_subject(cert: &openssl::x509::X509Ref) -> String {
+    cert.subject_name()
+        .entries()
+        .filter_map(|e| {
+            let obj = e.object().nid().short_name().ok()?;
+            let val = e.data().as_utf8().ok()?;
+            Some(format!("{obj}={val}"))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn log_tls_connection(ssl: &openssl::ssl::SslRef, addr: std::net::SocketAddr) {
+    match ssl.peer_certificate() {
+        Some(cert) => {
+            let subject = format_x509_subject(&cert);
+            info!("New TLS connection from {addr}, client cert: {subject}");
+        }
+        None => info!("New TLS connection from {addr}, no client cert"),
+    }
+}
+
 struct TlsListener {
     inner: TcpListener,
     acceptor: openssl::ssl::SslAcceptor,
@@ -342,7 +365,10 @@ impl axum::serve::Listener for TlsListener {
             .await;
 
             match res {
-                Ok(conn) => return conn,
+                Ok((tls_stream, addr)) => {
+                    log_tls_connection(tls_stream.ssl(), addr);
+                    return (tls_stream, addr);
+                }
                 Err(e) => warn!("{e}"),
             }
         }

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -585,6 +585,37 @@ async fn test_ws_userdb_get_user_record_more() {
     );
 }
 
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_varlink_conn_cache_reuses_connection() {
+    let sockets = Arc::new(VarlinkSockets::from_socket_dir("/run/systemd").unwrap());
+    let state = AppState {
+        varlink_sockets: sockets,
+        authenticators: Arc::new(Vec::new()),
+    };
+    let cache = VarlinkConnCache::new(None);
+
+    let conn1 = get_varlink_connection("io.systemd.Hostname", &state, &cache)
+        .await
+        .unwrap();
+    let conn2 = get_varlink_connection("io.systemd.Hostname", &state, &cache)
+        .await
+        .unwrap();
+    assert!(
+        Arc::ptr_eq(&conn1, &conn2),
+        "expected cached connection to be reused"
+    );
+
+    // different socket gets a different connection
+    let conn3 = get_varlink_connection("io.systemd.Manager", &state, &cache)
+        .await
+        .unwrap();
+    assert!(
+        !Arc::ptr_eq(&conn1, &conn3),
+        "different sockets should have different connections"
+    );
+}
+
 /// Parse a JSON text sequence (RFC 7464) body into a Vec of JSON values.
 /// Each record is RS (0x1E) + JSON + LF.
 fn parse_json_seq(body: &[u8]) -> Vec<Value> {

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -585,6 +585,101 @@ async fn test_ws_userdb_get_user_record_more() {
     );
 }
 
+/// Parse a JSON text sequence (RFC 7464) body into a Vec of JSON values.
+/// Each record is RS (0x1E) + JSON + LF.
+fn parse_json_seq(body: &[u8]) -> Vec<Value> {
+    body.split(|&b| b == 0x1e)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| {
+            let trimmed = chunk.strip_suffix(b"\n").unwrap_or(chunk);
+            serde_json::from_slice(trimmed).expect("json-seq record is not valid JSON")
+        })
+        .collect()
+}
+
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_jsonseq_hostname_describe() {
+    let (server, local_addr) = run_test_server("/run/systemd").await;
+    defer! {
+        server.abort();
+    };
+
+    let client = Client::new();
+    let res = client
+        .post(format!(
+            "http://{}/call/io.systemd.Hostname.Describe",
+            local_addr,
+        ))
+        .header("Accept", "application/json-seq")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("failed to post to test server");
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json-seq")
+    );
+
+    let body = res.bytes().await.expect("failed to read body");
+    let records = parse_json_seq(&body);
+
+    // non-streaming method: exactly one record
+    assert_eq!(
+        records.len(),
+        1,
+        "expected 1 json-seq record, got {records:#?}"
+    );
+    let expected_hostname = gethostname().into_string().expect("failed to get hostname");
+    assert_eq!(records[0]["Hostname"], expected_hostname);
+}
+
+#[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
+#[tokio::test]
+async fn test_jsonseq_userdb_get_user_record_more() {
+    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
+    defer! {
+        server.abort();
+    };
+
+    let client = Client::new();
+    let res = client
+        .post(format!(
+            "http://{}/call/io.systemd.UserDatabase.GetUserRecord?socket=io.systemd.Multiplexer",
+            local_addr,
+        ))
+        .header("Accept", "application/json-seq")
+        .json(&json!({"service": "io.systemd.Multiplexer"}))
+        .send()
+        .await
+        .expect("failed to post to test server");
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json-seq")
+    );
+
+    let body = res.bytes().await.expect("failed to read body");
+    let records = parse_json_seq(&body);
+
+    let users: Vec<&str> = records
+        .iter()
+        .filter_map(|r| r["record"]["userName"].as_str())
+        .collect();
+
+    // we expect at least root + current user
+    assert!(
+        users.len() >= 2,
+        "expected at least 2 user records, got {users:#?}"
+    );
+    assert!(users.contains(&"root"), "root user not found in {users:#?}");
+}
+
 #[test_with::path(/usr/bin/varlinkctl)]
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -9,7 +9,36 @@ use std::os::fd::OwnedFd;
 use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message as WsMsg;
 
-/// Build (if needed) and return the path to the varlinkctl-http binary.
+/// A simple log capture for tests.  Installed once (via `init_test_logger`)
+/// and accumulates all `info!` and above messages so tests can assert on them.
+struct TestLogger;
+
+static TEST_LOG_MESSAGES: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+impl log::Log for TestLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        TEST_LOG_MESSAGES
+            .lock()
+            .unwrap()
+            .push(format!("[{}] {}", record.level(), record.args()));
+    }
+
+    fn flush(&self) {}
+}
+
+fn init_test_logger() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        log::set_logger(&TestLogger).unwrap();
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+}
+
+/// Build (if needed) and return the path to the varlinkctl-helper binary.
 fn helper_binary() -> std::path::PathBuf {
     static BUILD: std::sync::Once = std::sync::Once::new();
 
@@ -959,6 +988,8 @@ async fn test_tls_basic_connection() {
 #[test_with::path(/usr/bin/openssl)]
 #[tokio::test]
 async fn test_mtls_accepts_client_cert_and_rejects_without() {
+    init_test_logger();
+
     let pki = make_test_pki();
     let varlink_dir = tempfile::tempdir().unwrap();
 
@@ -1009,6 +1040,15 @@ async fn test_mtls_accepts_client_cert_and_rejects_without() {
         .await
         .expect("mTLS connection with client cert failed");
     assert_eq!(res.status(), 200);
+
+    // Verify that the mTLS connection was logged with the client cert subject
+    let logs = TEST_LOG_MESSAGES.lock().unwrap();
+    assert!(
+        logs.iter()
+            .any(|msg| msg.contains("[INFO] New TLS connection from")
+                && msg.contains("client cert: CN=test-client")),
+        "expected mTLS connection log with client cert subject, got: {logs:?}"
+    );
 }
 
 #[test_with::path(/usr/bin/openssl)]
@@ -1171,6 +1211,42 @@ fn test_tls_credentials_directory_returns_none_without_creds() {
         result.is_none(),
         "empty credentials dir should yield no TLS"
     );
+}
+
+#[test_with::path(/usr/bin/openssl)]
+#[test]
+fn test_format_x509_subject() {
+    let pki = make_test_pki();
+    let pem = std::fs::read(&pki.client_cert_path).unwrap();
+    let cert = openssl::x509::X509::from_pem(&pem).unwrap();
+    let subject = format_x509_subject(&cert);
+    assert_eq!(subject, "CN=test-client");
+}
+
+#[test_with::path(/usr/bin/openssl)]
+#[test]
+fn test_format_x509_subject_multiple_fields() {
+    use std::process::Command;
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let d = tmpdir.path();
+    let key_path = d.join("key.pem");
+    let cert_path = d.join("cert.pem");
+    #[rustfmt::skip]
+    let openssl_args = [
+        "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+        "-keyout", key_path.to_str().unwrap(),
+        "-out",    cert_path.to_str().unwrap(),
+        "-subj",   "/O=TestOrg/CN=multi-field",
+        "-days",   "1",
+    ];
+    let out = Command::new("openssl").args(openssl_args).output().unwrap();
+    assert!(out.status.success());
+
+    let pem = std::fs::read(d.join("cert.pem")).unwrap();
+    let cert = openssl::x509::X509::from_pem(&pem).unwrap();
+    let subject = format_x509_subject(&cert);
+    assert_eq!(subject, "O=TestOrg, CN=multi-field");
 }
 
 // --- SSH key auth tests ---


### PR DESCRIPTION
bridge: support --more in plain http

This commit adds support for `more: true` in plain http. The caller
needs to send an `Accept: application/json-seq` header to indicate
it is ready for streaming replies. If so we call the varlink
endpoint with `more: true` and replies with a json-seq reply for
each varlink data frame.

Thanks to @arianvp for suggesting this in
https://gist.github.com/arianvp/314113d4309c7d7d3047535e167352ac
(note that this commit does not do the connection reuse yet).

---

bridge: reuse varlink connection for the entire connection
 duration

This commit implements the final part of @arianvp suggestion (thanks!)
for the varlink http improvements - cache the varlink connection during
the entire connection lifetime.

C.f. https://gist.github.com/arianvp/314113d4309c7d7d3047535e167352ac

---

bridge: log remote IP and client cert fingerprint

Log the client IP and (when available) mTLS cert fingerprint for
each connection.

