### PR TITLE
many: various tweak naming, service, auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,7 +2447,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "varlink-http-bridge"
+name = "varlink-httpd"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "varlink-http-bridge"
+name = "varlink-httpd"
 version = "0.1.0"
 edition = "2024"
 license = "LGPL-2.1-or-later"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# varlink-http-bridge
+# varlink-httpd
 
 This is a http bridge to make local varlink services available via
 http. The main use case is systemd, so only the subset of varlink that
@@ -53,7 +53,7 @@ Using curl for direct calls is usually more convenient/ergonimic than
 using the websocket endpoint.
 
 ```console
-$ systemd-run --user ./target/debug/varlink-http-bridge
+$ systemd-run --user ./target/debug/varlink-httpd
 
 $ curl -s http://localhost:1031/sockets | jq
 {
@@ -119,7 +119,7 @@ Systemd version v260+ supports pluggable protocols for varlink, with that the br
 becomes even nicer.
 
 ```console
-# copy varlinkctl-helper into /usr/lib/systemd/varlink-bridges/http
+# copy varlinkctl-http into /usr/lib/systemd/varlink-bridges/http
 # (or use SYSTEMD_VARLINK_BRIDGES_DIR)
 $ varlinkctl introspect http://localhost:1031/ws/sockets/io.systemd.Hostname
 interface io.systemd
@@ -166,9 +166,9 @@ $ printf '{"method":"io.systemd.UserDatabase.GetUserRecord", "parameters": {"ser
       "gid": 0,
 ...
 
-# varlinkctl is supported via our varlinkctl-helper
+# varlinkctl is supported via our varlinkctl-http
 $ VARLINK_BRIDGE_URL=http://localhost:1031/ws/sockets/io.systemd.Multiplexer \
-    varlinkctl call --more /usr/libexec/varlinkctl-helper \
+    varlinkctl call --more /usr/libexec/varlinkctl-http \
 	io.systemd.UserDatabase.GetUserRecord '{"service":"io.systemd.Multiplexer"}'
 
 
@@ -216,14 +216,14 @@ LoadCredential=trust:/etc/ssl/ca/client-ca.pem
 
 Explicit CLI flags take priority over credentials directory files.
 
-### Client (varlinkctl-helper)
+### Client (varlinkctl-http)
 
-The `varlinkctl-helper` binary acts as a bridge between `varlinkctl`
-and `varlink-http-bridge`, supporting TLS and mTLS. It looks for
+The `varlinkctl-http` binary acts as a bridge between `varlinkctl`
+and `varlink-httpd`, supporting TLS and mTLS. It looks for
 client credentials in the first existing directory:
 
-* `$XDG_CONFIG_HOME/varlink-http-bridge/`
-* `~/.config/varlink-http-bridge/`
+* `$XDG_CONFIG_HOME/varlink-httpd/`
+* `~/.config/varlink-httpd/`
 * `$CREDENTIALS_DIRECTORY`
 
 The credential file names are:
@@ -238,13 +238,13 @@ The system CAs are used automatically. For mTLS, drop the client cert
 and key into the config directory:
 
 ```console
-$ mkdir -p ~/.config/varlink-http-bridge
-$ cp client-cert.pem ~/.config/varlink-http-bridge/client-cert-file
-$ cp client-key.pem  ~/.config/varlink-http-bridge/client-key-file
-$ cp ca.pem          ~/.config/varlink-http-bridge/server-ca-file
+$ mkdir -p ~/.config/varlink-httpd
+$ cp client-cert.pem ~/.config/varlink-httpd/client-cert-file
+$ cp client-key.pem  ~/.config/varlink-httpd/client-key-file
+$ cp ca.pem          ~/.config/varlink-httpd/server-ca-file
 
 $ VARLINK_BRIDGE_URL=https://myhost:1031/ws/sockets/io.systemd.Hostname \
-    varlinkctl call exec:/usr/libexec/varlinkctl-helper \
+    varlinkctl call exec:/usr/libexec/varlinkctl-http \
     io.systemd.Hostname.Describe '{}'
 ```
 
@@ -261,29 +261,29 @@ The bridge discovers authorized keys automatically from these
 locations (first match wins):
 
 1. `--authorized-keys=PATH` — explicit CLI flag
-2. `/etc/varlink-http-bridge/authorized_keys` — config file
+2. `/etc/varlink-httpd/authorized_keys` — config file
 3. `$CREDENTIALS_DIRECTORY/ssh.authorized_keys.root` — systemd per-service credential (see `systemd.exec(5)`)
 4. `/run/credentials/@system/ssh.authorized_keys.root` — system-wide credential (see `systemd.system-credentials(7)`)
 
 The simplest setup is to pass the path explicitly:
 
 ```console
-$ varlink-http-bridge --authorized-keys=~/.ssh/authorized_keys
+$ varlink-httpd --authorized-keys=~/.ssh/authorized_keys
 ```
 
 To fetch keys from GitHub (or any HTTPS URL) and save them locally,
 use the `import-ssh` subcommand:
 
 ```console
-$ run0 varlink-http-bridge import-ssh gh:myuser
-Wrote 3 key line(s) to /etc/varlink-http-bridge/authorized_keys, run with:
-  varlink-http-bridge --authorized-keys /etc/varlink-http-bridge/authorized_keys
+$ run0 varlink-httpd import-ssh gh:myuser
+Wrote 3 key line(s) to /etc/varlink-httpd/authorized_keys, run with:
+  varlink-httpd --authorized-keys /etc/varlink-httpd/authorized_keys
 ```
 
 The source can be `gh:<user>` (shorthand for
 `https://github.com/<user>.keys`) or any `https://` URL.  The output
 path is auto-detected but can be overridden with a second positional
-argument.  Once written to `/etc/varlink-http-bridge/authorized_keys`,
+argument.  Once written to `/etc/varlink-httpd/authorized_keys`,
 the bridge picks up the file automatically (discovery path 2) so the
 `--authorized-keys` flag is no longer needed.
 
@@ -297,7 +297,7 @@ LoadCredential=ssh.authorized_keys.root:/root/.ssh/authorized_keys
 
 ### Client setup (key selection)
 
-The varlinkctl-helper uses two methods for signing, checked in order:
+The varlinkctl-http uses two methods for signing, checked in order:
 
 1. **`VARLINK_SSH_KEY`** — If the private key is passed it will read
    the private key file directly. If the public key is passed it will
@@ -327,7 +327,7 @@ example, use regular TLS (not mTLS) for transport encryption and SSH
 keys for user authentication:
 
 ```console
-$ varlink-http-bridge \
+$ varlink-httpd \
     --cert=server.pem \
     --key=server-key.pem \
     --authorized-keys=~/.ssh/authorized_keys

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ http. The main use case is systemd, so only the subset of varlink that
 systemd needs is supported right now.
 
 It takes a directory with varlink sockets (or symlinks to varlink
-sockets) like /run/systemd/registry as the argument and will serve
+sockets) like /run/varlink/registry as the argument and will serve
 whatever it finds in there. Sockets can be added or removed dynamically
 in the dir as needed.
 

--- a/data/varlink-http-bridge.service.in
+++ b/data/varlink-http-bridge.service.in
@@ -10,7 +10,8 @@
 
 [Unit]
 Description=Varlink HTTP Bridge
-After=network.target
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Service]
 Type=simple
@@ -19,4 +20,4 @@ Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network.target

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -15,7 +15,7 @@ Conflicts=shutdown.target
 
 [Service]
 Type=simple
-ExecStart=@bindir@/varlink-http-bridge --bind 0.0.0.0:1031
+ExecStart=@bindir@/varlink-httpd --bind 0.0.0.0:1031
 Restart=on-failure
 RestartSec=5
 

--- a/justfile
+++ b/justfile
@@ -7,9 +7,9 @@ bridgedir := prefix / "lib/systemd/varlink-bridges"
 install: install_server install_client
 
 install_server: (build "release")
-	install -Dm755 {{srv_binary}} {{destdir}}{{bindir}}/varlink-http-bridge
+	install -Dm755 {{srv_binary}} {{destdir}}{{bindir}}/varlink-httpd
 	install -dm755 {{destdir}}{{unitdir}}
-	sed 's|@bindir@|{{bindir}}|g' data/varlink-http-bridge.service.in > {{destdir}}{{unitdir}}/varlink-http-bridge.service
+	sed 's|@bindir@|{{bindir}}|g' data/varlink-httpd.service.in > {{destdir}}{{unitdir}}/varlink-httpd.service
 
 install_client: (build "release")
 	install -Dm755 {{helper_binary}} {{destdir}}{{bridgedir}}/http
@@ -29,13 +29,13 @@ test:
 	cargo test
 
 # the httpd service
-srv_binary := "target/release/varlink-http-bridge"
+srv_binary := "target/release/varlink-httpd"
 # max_size_kb is a bit arbitrary but it should ensure we don't increase size too much
 # without noticing (currently at 3.2MB)
 srv_max_size := "4 * 1024 * 1024"
 
-# the varlinkctl helper binary so that varlinkctl exec:varlinkctl-helper can talk to http
-helper_binary := "target/release/varlinkctl-helper"
+# the varlinkctl http transport so that varlinkctl can talk over http/ws
+helper_binary := "target/release/varlinkctl-http"
 helper_max_size := "2 * 1024 * 1024"
 
 [script]
@@ -54,8 +54,8 @@ check_helper_binary_size:
 	cargo build --release
 	max_size_kb="$(({{helper_max_size}} / 1024 ))"
 	cur_size_kb=$(( $(stat --format='%s' {{helper_binary}}) / 1024 ))
-	echo "release varlinkctl-helper binary: ${cur_size_kb}KB / ${max_size_kb}KB"
+	echo "release varlinkctl-http binary: ${cur_size_kb}KB / ${max_size_kb}KB"
 	if [ "$cur_size_kb" -gt "$max_size_kb" ]; then
-	  echo "ERROR: release varlinkctl-helper binary exceeds limit"
+	  echo "ERROR: release varlinkctl-http binary exceeds limit"
 	  exit 1
 	fi

--- a/src/auth_ssh.rs
+++ b/src/auth_ssh.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
 use crate::Authenticator;
-use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER};
+use varlink_httpd::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER};
 
 struct KeyCache {
     keys: HashMap<String, PublicKey>,
@@ -211,7 +211,7 @@ pub(crate) fn maybe_create_ssh_authenticator(
     // Priority: explicit CLI > /etc config > $CREDENTIALS_DIRECTORY >
     // system-wide /run/credentials/@system/ (see systemd.system-credentials(7))
     let authorized_keys_path = cli_authorized_keys
-        .or_else(|| exists(&root.join("etc/varlink-http-bridge/authorized_keys")))
+        .or_else(|| exists(&root.join("etc/varlink-httpd/authorized_keys")))
         .or_else(|| creds_dir.and_then(|d| exists(&d.join(SSH_AUTHORIZED_KEYS_CREDENTIAL))))
         .or_else(|| {
             exists(

--- a/src/auth_ssh.rs
+++ b/src/auth_ssh.rs
@@ -195,9 +195,13 @@ pub(crate) fn extract_nonce(headers: &axum::http::HeaderMap) -> Option<String> {
         .map(String::from)
 }
 
-/// Well-known credential name for SSH authorized keys, see
-/// systemd.system-credentials(7).
-const SSH_AUTHORIZED_KEYS_CREDENTIAL: &str = "ssh.authorized_keys.root";
+/// Well-known credential names for SSH authorized keys, see
+/// systemd.system-credentials(7).  The dedicated credential is checked
+/// first so it takes priority over the broader ephemeral one.
+const SSH_AUTHORIZED_KEYS_CREDENTIALS: &[&str] = &[
+    "ssh.authorized_keys.root",
+    "ssh.ephemeral-authorized_keys-all",
+];
 
 pub(crate) fn maybe_create_ssh_authenticator(
     cli_authorized_keys: Option<String>,
@@ -212,13 +216,18 @@ pub(crate) fn maybe_create_ssh_authenticator(
     // system-wide /run/credentials/@system/ (see systemd.system-credentials(7))
     let authorized_keys_path = cli_authorized_keys
         .or_else(|| exists(&root.join("etc/varlink-httpd/authorized_keys")))
-        .or_else(|| creds_dir.and_then(|d| exists(&d.join(SSH_AUTHORIZED_KEYS_CREDENTIAL))))
         .or_else(|| {
-            exists(
-                &root
-                    .join("run/credentials/@system")
-                    .join(SSH_AUTHORIZED_KEYS_CREDENTIAL),
-            )
+            creds_dir.and_then(|d| {
+                SSH_AUTHORIZED_KEYS_CREDENTIALS
+                    .iter()
+                    .find_map(|name| exists(&d.join(name)))
+            })
+        })
+        .or_else(|| {
+            let sys_creds = root.join("run/credentials/@system");
+            SSH_AUTHORIZED_KEYS_CREDENTIALS
+                .iter()
+                .find_map(|name| exists(&sys_creds.join(name)))
         });
 
     let Some(ak_path) = authorized_keys_path else {

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -70,8 +70,8 @@ fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
 
 /// Build an `SslConnector` with client certs and a custom CA loaded from the
 /// first existing directory:
-/// 1. `$XDG_CONFIG_HOME/varlink-http-bridge/`
-/// 2. `~/.config/varlink-http-bridge/`
+/// 1. `$XDG_CONFIG_HOME/varlink-httpd/`
+/// 2. `~/.config/varlink-httpd/`
 /// 3. `$CREDENTIALS_DIRECTORY` (systemd, see systemd.exec(5))
 fn build_ssl_connector() -> Result<SslConnector> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
@@ -80,8 +80,8 @@ fn build_ssl_connector() -> Result<SslConnector> {
     builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
 
     let maybe_credentials_dirs = [
-        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlink-http-bridge")),
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlink-http-bridge")),
+        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlink-httpd")),
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlink-httpd")),
         std::env::var_os("CREDENTIALS_DIRECTORY").map(PathBuf::from),
     ];
     if let Some(dir) = maybe_credentials_dirs
@@ -145,7 +145,7 @@ fn connect_ws(url: &str) -> Result<Ws> {
 
     let tls_channel_binding = match &stream {
         Stream::Tls(ssl_stream) => {
-            use varlink_http_bridge::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
+            use varlink_httpd::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
             let mut buf = [0u8; TLS_CHANNEL_BINDING_LEN];
             ssl_stream
                 .ssl()

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result, bail};
 use log::{debug, warn};
-use varlink_http_bridge::SSHAUTH_MAGIC_PREFIX;
+use varlink_httpd::SSHAUTH_MAGIC_PREFIX;
 
 struct Signer {
     builder: sshauth::signer::TokenSignerBuilder,
@@ -45,7 +45,7 @@ pub(crate) fn maybe_add_auth_headers(
         bearer.parse().context("invalid auth header value")?,
     );
     request.headers_mut().insert(
-        varlink_http_bridge::SSHAUTH_NONCE_HEADER,
+        varlink_httpd::SSHAUTH_NONCE_HEADER,
         nonce.parse().context("invalid nonce header value")?,
     );
     Ok(())

--- a/src/import_ssh.rs
+++ b/src/import_ssh.rs
@@ -27,7 +27,7 @@ fn default_authorized_keys_path() -> String {
             .into_owned();
     }
     if rustix::process::getuid().is_root() {
-        return "/etc/varlink-http-bridge/authorized_keys".to_string();
+        return "/etc/varlink-httpd/authorized_keys".to_string();
     }
     let config_dir = std::env::var_os("XDG_CONFIG_HOME").map_or_else(
         || {
@@ -37,7 +37,7 @@ fn default_authorized_keys_path() -> String {
         std::path::PathBuf::from,
     );
     config_dir
-        .join("varlink-http-bridge/authorized_keys")
+        .join("varlink-httpd/authorized_keys")
         .to_string_lossy()
         .into_owned()
 }
@@ -96,9 +96,9 @@ pub(crate) fn run(cmd: ImportSsh) -> anyhow::Result<()> {
         keys_count = keys.len()
     );
     if std::env::var_os("CREDENTIALS_DIRECTORY").is_some() {
-        eprintln!("  varlink-http-bridge");
+        eprintln!("  varlink-httpd");
     } else {
-        eprintln!("  varlink-http-bridge --authorized-keys={output_path}");
+        eprintln!("  varlink-httpd --authorized-keys={output_path}");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ use axum::serve::IncomingStream;
 
 impl Connected<IncomingStream<'_, TlsListener>> for TlsConnectionInfo {
     fn connect_info(target: IncomingStream<'_, TlsListener>) -> Self {
-        use varlink_http_bridge::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
+        use varlink_httpd::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
 
         let mut buf = [0u8; TLS_CHANNEL_BINDING_LEN];
         target
@@ -768,32 +768,32 @@ struct BridgeCli {
 
 fn print_help() {
     eprint!(indoc::indoc! {"
-        Usage: varlink-http-bridge [OPTIONS] [VARLINK_SOCKETS_PATH]
+        Usage: varlink-httpd [bridge] [OPTIONS] [VARLINK_SOCKETS_PATH]
+               varlink-httpd import-ssh SOURCE [OUTPUT]
 
-        A proxy for Varlink sockets.
-
-        Positional arguments:
-          VARLINK_SOCKETS_PATH  directory of sockets or a single socket
-                                (default: /run/varlink/registry)
-
-        Options:
-          --bind=ADDR             address to bind HTTP server to (default: 0.0.0.0:1031)
-          --cert=PATH             path to TLS certificate PEM file
-          --key=PATH              path to TLS private key PEM file
-          --trust=PATH            path to CA certificate PEM for client verification (mTLS)
-          --authorized-keys=PATH  path to authorized SSH public keys file
-          --insecure              allow running without any authentication (DANGEROUS)
-          --help                  display this help and exit
+        A HTTP/WebSocket daemon for varlink sockets.
 
         Subcommands:
-          import-ssh SOURCE [OUTPUT]  download SSH authorized keys from a URL
+          bridge (default)                  start the HTTP/WebSocket server
+          import-ssh SOURCE [OUTPUT]        download SSH authorized keys from a URL
+
+        Bridge options:
+          VARLINK_SOCKETS_PATH              directory of sockets or a single socket
+                                            (default: /run/varlink/registry)
+          --bind=ADDR                       address to bind to (default: 0.0.0.0:1031)
+          --cert=PATH                       TLS certificate PEM file
+          --key=PATH                        TLS private key PEM file
+          --trust=PATH                      CA certificate PEM for client verification (mTLS)
+          --authorized-keys=PATH            authorized SSH public keys file
+          --insecure                        run without any authentication (DANGEROUS)
+          --help                            display this help and exit
     "});
 }
 
 #[cfg(feature = "sshauth")]
 fn print_import_ssh_help() {
     eprint!(indoc::indoc! {"
-        Usage: varlink-http-bridge import-ssh SOURCE [OUTPUT]
+        Usage: varlink-httpd import-ssh SOURCE [OUTPUT]
 
         Download SSH authorized keys from a URL and save to a local file.
 
@@ -834,6 +834,10 @@ fn parse_cli() -> anyhow::Result<Command> {
             #[cfg(feature = "sshauth")]
             Value(val) if !got_positional && val == "import-ssh" => {
                 return parse_import_ssh_args(&mut parser);
+            }
+            Value(val) if !got_positional && val == "bridge" => {
+                // explicit "bridge" subcommand — just consume the keyword
+                got_positional = false;
             }
             Value(val) if !got_positional => {
                 varlink_sockets_path = val.parse()?;
@@ -891,7 +895,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Bridge(cli) => cli,
     };
 
-    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-http-bridge"
+    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"
     let mut listenfd = ListenFd::from_env();
     let listener = if let Some(std_listener) = listenfd.take_tcp_listener(0)? {
         // needed or tokio panics, see https://github.com/mitsuhiko/listenfd/pull/23

--- a/src/main.rs
+++ b/src/main.rs
@@ -774,7 +774,7 @@ fn print_help() {
 
         Positional arguments:
           VARLINK_SOCKETS_PATH  directory of sockets or a single socket
-                                (default: /run/systemd/registry)
+                                (default: /run/varlink/registry)
 
         Options:
           --bind=ADDR             address to bind HTTP server to (default: 0.0.0.0:1031)
@@ -810,7 +810,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     use lexopt::prelude::*;
 
     let mut bind = String::from("0.0.0.0:1031");
-    let mut varlink_sockets_path = String::from("/run/systemd/registry");
+    let mut varlink_sockets_path = String::from("/run/varlink/registry");
     let mut cert = None;
     let mut key = None;
     let mut trust = None;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1525,6 +1525,65 @@ mod sshauth_tests {
             "creds_dir (1 key) should take priority over /run (2 keys)"
         );
 
+        // 5b. ssh.ephemeral-authorized_keys-all is used when .root is absent (creds_dir)
+        let creds_dir_all = tempfile::tempdir().unwrap();
+        std::fs::write(
+            creds_dir_all
+                .path()
+                .join("ssh.ephemeral-authorized_keys-all"),
+            pubkey_a.as_bytes(),
+        )
+        .unwrap();
+        let auth =
+            maybe_create_ssh_authenticator(None, Some(creds_dir_all.path()), empty_root.path())
+                .unwrap()
+                .unwrap();
+        assert_eq!(auth.key_count(), 1, "should find key from .all credential");
+
+        // 5c. ssh.authorized_keys.root takes priority over .all (creds_dir)
+        let creds_dir_both = tempfile::tempdir().unwrap();
+        std::fs::write(
+            creds_dir_both.path().join("ssh.authorized_keys.root"),
+            pubkey_a.as_bytes(),
+        )
+        .unwrap();
+        let mut all_file = std::fs::File::create(
+            creds_dir_both
+                .path()
+                .join("ssh.ephemeral-authorized_keys-all"),
+        )
+        .unwrap();
+        writeln!(all_file, "{}", pubkey_b1.trim()).unwrap();
+        writeln!(all_file, "{}", pubkey_b2.trim()).unwrap();
+        drop(all_file);
+        let auth =
+            maybe_create_ssh_authenticator(None, Some(creds_dir_both.path()), empty_root.path())
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            auth.key_count(),
+            1,
+            ".root (1 key) should take priority over .all (2 keys)"
+        );
+
+        // 5d. ssh.ephemeral-authorized_keys-all in /run/credentials/@system
+        let root_run_all = tempfile::tempdir().unwrap();
+        let run_dir = root_run_all.path().join("run/credentials/@system");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        std::fs::write(
+            run_dir.join("ssh.ephemeral-authorized_keys-all"),
+            pubkey_a.as_bytes(),
+        )
+        .unwrap();
+        let auth = maybe_create_ssh_authenticator(None, None, root_run_all.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            auth.key_count(),
+            1,
+            "should find key from .all in /run path"
+        );
+
         // 6. CLI path overrides everything
         let cli_root = make_test_rootdir_with_keys(&[pubkey_a.trim()]);
         let cli_file = tempfile::NamedTempFile::new().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ use std::os::fd::OwnedFd;
 use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message as WsMsg;
 
-/// Build (if needed) and return the path to the varlinkctl-helper binary.
+/// Build (if needed) and return the path to the varlinkctl-http binary.
 fn helper_binary() -> std::path::PathBuf {
     static BUILD: std::sync::Once = std::sync::Once::new();
 
@@ -20,17 +20,14 @@ fn helper_binary() -> std::path::PathBuf {
         .unwrap()
         .parent()
         .unwrap()
-        .join("varlinkctl-helper");
+        .join("varlinkctl-http");
 
     BUILD.call_once(|| {
         let status = std::process::Command::new(env!("CARGO"))
-            .args(["build", "--bin", "varlinkctl-helper"])
+            .args(["build", "--bin", "varlinkctl-http"])
             .status()
             .expect("failed to run cargo build");
-        assert!(
-            status.success(),
-            "cargo build --bin varlinkctl-helper failed"
-        );
+        assert!(status.success(), "cargo build --bin varlinkctl-http failed");
     });
 
     helper
@@ -945,7 +942,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
     };
 
     let fake_xdg_home = tempfile::tempdir().unwrap();
-    let tls_dir = fake_xdg_home.path().join("varlink-http-bridge");
+    let tls_dir = fake_xdg_home.path().join("varlink-httpd");
     std::fs::create_dir_all(&tls_dir).unwrap();
     std::fs::copy(&pki.client_cert_path, tls_dir.join("client-cert-file")).unwrap();
     std::fs::copy(&pki.client_key_path, tls_dir.join("client-key-file")).unwrap();
@@ -1006,7 +1003,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
 
     // Provide the server CA (so the client trusts the server) but NO client cert/key
     let fake_xdg_home = tempfile::tempdir().unwrap();
-    let tls_dir = fake_xdg_home.path().join("varlink-http-bridge");
+    let tls_dir = fake_xdg_home.path().join("varlink-httpd");
     std::fs::create_dir_all(&tls_dir).unwrap();
     std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
 
@@ -1057,11 +1054,11 @@ mod sshauth_tests {
     use super::*;
     use crate::maybe_create_ssh_authenticator;
 
-    /// Create a fake rootdir with an `etc/varlink-http-bridge/authorized_keys` file.
+    /// Create a fake rootdir with an `etc/varlink-httpd/authorized_keys` file.
     fn make_test_rootdir_with_keys(pubkeys: &[&str]) -> tempfile::TempDir {
         use std::io::Write;
         let root = tempfile::tempdir().unwrap();
-        let dir = root.path().join("etc/varlink-http-bridge");
+        let dir = root.path().join("etc/varlink-httpd");
         std::fs::create_dir_all(&dir).unwrap();
         let mut f = std::fs::File::create(dir.join("authorized_keys")).unwrap();
         for key in pubkeys {
@@ -1261,7 +1258,7 @@ mod sshauth_tests {
                 Request::get("/sockets")
                     .header("Authorization", "Bearer bogus-token")
                     .header(
-                        varlink_http_bridge::SSHAUTH_NONCE_HEADER,
+                        varlink_httpd::SSHAUTH_NONCE_HEADER,
                         "a-nonce-long-enough-1234",
                     )
                     .body(Body::empty())
@@ -1463,7 +1460,7 @@ mod sshauth_tests {
         let result = maybe_create_ssh_authenticator(None, None, empty_root.path()).unwrap();
         assert!(result.is_none(), "empty rootdir should yield None");
 
-        // 2. rootdir/etc/varlink-http-bridge/authorized_keys exists → found
+        // 2. rootdir/etc/varlink-httpd/authorized_keys exists → found
         let root = make_test_rootdir_with_keys(&[pubkey_a.trim()]);
         let auth = maybe_create_ssh_authenticator(None, None, root.path())
             .unwrap()
@@ -1486,7 +1483,7 @@ mod sshauth_tests {
 
         // 4. Both /etc and /run exist → /etc takes priority (1 key vs 2 keys)
         let root_both = tempfile::tempdir().unwrap();
-        let etc_dir = root_both.path().join("etc/varlink-http-bridge");
+        let etc_dir = root_both.path().join("etc/varlink-httpd");
         std::fs::create_dir_all(&etc_dir).unwrap();
         std::fs::write(etc_dir.join("authorized_keys"), pubkey_a.as_bytes()).unwrap();
         let run_dir = root_both.path().join("run/credentials/@system");
@@ -1564,7 +1561,7 @@ mod sshauth_tests {
         };
 
         let fake_xdg_home = tempfile::tempdir().unwrap();
-        let tls_dir = fake_xdg_home.path().join("varlink-http-bridge");
+        let tls_dir = fake_xdg_home.path().join("varlink-httpd");
         std::fs::create_dir_all(&tls_dir).unwrap();
         std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
 


### PR DESCRIPTION
naming: rename to varlink-httpd, varlinkctl-http

Now that we have the varlinkctl protocol plugin helper the
naming is a little bit confusing. So this is an attempt
to clean it up a bit:
- varlink-httpd for the http bridge
- varlinkctl-http for the client plugin

This will also make the packaging easier as the packages
now reflect the purpose better.

---

data: switch WantedBy to sockets.target

This was `WantedBy=multi-user.target` which blocks on
firstboot but the varlink bridge is useful even before
so lets make sure its available early enough.

---

bridge: fix default varlink dir

This fixes a silly typo, the default registry dir for
varlink is /run/varlink/registry

---


auth: support ssh.ephemeral-authorized_keys-all

This is what vmspawn uses so lets support this as well.
