### PR TITLE
varlinkctl-http: use ~/.config/varlinkctl-http for client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,11 @@ Explicit CLI flags take priority over credentials directory files.
 
 The `varlinkctl-http` binary acts as a bridge between `varlinkctl`
 and `varlink-httpd`, supporting TLS and mTLS. It looks for
-client credentials in the first existing directory:
+client TLS material in the first existing directory:
 
 * `$XDG_CONFIG_HOME/varlinkctl-http/`
 * `~/.config/varlinkctl-http/`
-* `$CREDENTIALS_DIRECTORY`
-
-The credential file names are:
+* `/etc/varlinkctl-http/`
 
 | File                   | Purpose                                   |
 |------------------------|-------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ The `varlinkctl-http` binary acts as a bridge between `varlinkctl`
 and `varlink-httpd`, supporting TLS and mTLS. It looks for
 client credentials in the first existing directory:
 
-* `$XDG_CONFIG_HOME/varlink-httpd/`
-* `~/.config/varlink-httpd/`
+* `$XDG_CONFIG_HOME/varlinkctl-http/`
+* `~/.config/varlinkctl-http/`
 * `$CREDENTIALS_DIRECTORY`
 
 The credential file names are:
@@ -243,10 +243,10 @@ The system CAs are used automatically. For mTLS, drop the client cert
 and key into the config directory:
 
 ```console
-$ mkdir -p ~/.config/varlink-httpd
-$ cp client-cert.pem ~/.config/varlink-httpd/client-cert-file
-$ cp client-key.pem  ~/.config/varlink-httpd/client-key-file
-$ cp ca.pem          ~/.config/varlink-httpd/server-ca-file
+$ mkdir -p ~/.config/varlinkctl-http
+$ cp client-cert.pem ~/.config/varlinkctl-http/client-cert-file
+$ cp client-key.pem  ~/.config/varlinkctl-http/client-key-file
+$ cp ca.pem          ~/.config/varlinkctl-http/server-ca-file
 
 $ VARLINK_BRIDGE_URL=https://myhost:1031/ws/sockets/io.systemd.Hostname \
     varlinkctl call exec:/usr/libexec/varlinkctl-http \

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1108,7 +1108,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
     };
 
     let fake_xdg_home = tempfile::tempdir().unwrap();
-    let tls_dir = fake_xdg_home.path().join("varlink-httpd");
+    let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
     std::fs::create_dir_all(&tls_dir).unwrap();
     std::fs::copy(&pki.client_cert_path, tls_dir.join("client-cert-file")).unwrap();
     std::fs::copy(&pki.client_key_path, tls_dir.join("client-key-file")).unwrap();
@@ -1169,7 +1169,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
 
     // Provide the server CA (so the client trusts the server) but NO client cert/key
     let fake_xdg_home = tempfile::tempdir().unwrap();
-    let tls_dir = fake_xdg_home.path().join("varlink-httpd");
+    let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
     std::fs::create_dir_all(&tls_dir).unwrap();
     std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
 
@@ -1822,7 +1822,7 @@ mod sshauth_tests {
         };
 
         let fake_xdg_home = tempfile::tempdir().unwrap();
-        let tls_dir = fake_xdg_home.path().join("varlink-httpd");
+        let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
         std::fs::create_dir_all(&tls_dir).unwrap();
         std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
 

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -72,23 +72,20 @@ fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
 /// first existing directory:
 /// 1. `$XDG_CONFIG_HOME/varlinkctl-http/`
 /// 2. `~/.config/varlinkctl-http/`
-/// 3. `$CREDENTIALS_DIRECTORY` (systemd, see systemd.exec(5))
+/// 3. `/etc/varlinkctl-http/`
 fn build_ssl_connector() -> Result<SslConnector> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
     // We need tls channel binding per RFC 9266 ("tls-exporter") which
     // is only guaranteed unique with TLS 1.3.
     builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
 
-    let maybe_credentials_dirs = [
+    let config_dirs = [
         std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlinkctl-http")),
         std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlinkctl-http")),
-        std::env::var_os("CREDENTIALS_DIRECTORY").map(PathBuf::from),
+        Some(PathBuf::from("/etc/varlinkctl-http")),
     ];
-    if let Some(dir) = maybe_credentials_dirs
-        .into_iter()
-        .flatten()
-        .find(|d| d.is_dir())
-    {
+
+    if let Some(dir) = config_dirs.into_iter().flatten().find(|d| d.is_dir()) {
         let cert = dir.join("client-cert-file");
         let key = dir.join("client-key-file");
         let ca = dir.join("server-ca-file");

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -70,8 +70,8 @@ fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
 
 /// Build an `SslConnector` with client certs and a custom CA loaded from the
 /// first existing directory:
-/// 1. `$XDG_CONFIG_HOME/varlink-httpd/`
-/// 2. `~/.config/varlink-httpd/`
+/// 1. `$XDG_CONFIG_HOME/varlinkctl-http/`
+/// 2. `~/.config/varlinkctl-http/`
 /// 3. `$CREDENTIALS_DIRECTORY` (systemd, see systemd.exec(5))
 fn build_ssl_connector() -> Result<SslConnector> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
@@ -80,8 +80,8 @@ fn build_ssl_connector() -> Result<SslConnector> {
     builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
 
     let maybe_credentials_dirs = [
-        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlink-httpd")),
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlink-httpd")),
+        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlinkctl-http")),
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlinkctl-http")),
         std::env::var_os("CREDENTIALS_DIRECTORY").map(PathBuf::from),
     ];
     if let Some(dir) = maybe_credentials_dirs


### PR DESCRIPTION
The configuration for the `varlinkctl-http` client is curently in `~/.config/varlink-httpd`. This is confusing so this commit tweaks it so that it moves into `~/.config/varlinkctl-http`.