### PR TITLE
varlink-httpd: cleanup systemd credentials usage/imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,18 +208,21 @@ require clients to present a certificate signed by that CA.
 
 ### systemd credentials
 
-When running as a systemd service, the bridge automatically discovers
-TLS material from `$CREDENTIALS_DIRECTORY` (see `systemd.exec(5)`).
-The credential file names match the CLI flag names:
+When running as a systemd service, the bridge discovers TLS material
+from `$CREDENTIALS_DIRECTORY` (see `systemd.exec(5)`).  The credential
+file names match the CLI flag names: `cert`, `key`, `trust`.
 
-```ini
-[Service]
-LoadCredential=cert:/etc/ssl/certs/bridge.pem
-LoadCredential=key:/etc/ssl/private/bridge.pem
-LoadCredential=trust:/etc/ssl/ca/client-ca.pem
+The shipped unit file (`varlink-httpd.service`) uses `ImportCredential=`
+to import well-known credential names from the credstore and rename
+them to the short names the service expects.  To provision TLS:
+
+```console
+# cp server.pem     /etc/credstore/varlink-httpd.tls.certificate
+# systemd-creds encrypt server-key.pem /etc/credstore.encrypted/varlink-httpd.tls.key
+# cp ca.pem         /etc/credstore/varlink-httpd.tls.trust
 ```
 
-Explicit CLI flags take priority over credentials directory files.
+Explicit CLI flags take priority over credentials.
 
 ### Client (varlinkctl-http)
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,7 @@ locations (first match wins):
 
 1. `--authorized-keys=PATH` — explicit CLI flag
 2. `/etc/varlink-httpd/authorized_keys` — config file
-3. `$CREDENTIALS_DIRECTORY/ssh.authorized_keys.root` — systemd per-service credential (see `systemd.exec(5)`)
-4. `/run/credentials/@system/ssh.authorized_keys.root` — system-wide credential (see `systemd.system-credentials(7)`)
+3. `$CREDENTIALS_DIRECTORY/ssh.authorized_keys.root` — systemd credential (see `systemd.exec(5)`)
 
 The simplest setup is to pass the path explicitly:
 

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -19,5 +19,16 @@ ExecStart=@bindir@/varlink-httpd --bind 0.0.0.0:1031
 Restart=on-failure
 RestartSec=5
 
+# TLS credentials: well-known names from the credstore, renamed to the
+# short names the service expects in $CREDENTIALS_DIRECTORY.
+# Place certs in /etc/credstore/ and keys in /etc/credstore.encrypted/.
+ImportCredential=varlink-httpd.tls.certificate:cert
+ImportCredential=varlink-httpd.tls.key:key
+ImportCredential=varlink-httpd.tls.trust:trust
+
+# SSH authorized keys (see systemd.system-credentials(7))
+ImportCredential=ssh.authorized_keys.root
+ImportCredential=ssh.ephemeral-authorized_keys-all
+
 [Install]
 WantedBy=network.target

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -212,8 +212,8 @@ pub(crate) fn maybe_create_ssh_authenticator(
         p.exists().then(|| p.to_string_lossy().to_string())
     }
 
-    // Priority: explicit CLI > /etc config > $CREDENTIALS_DIRECTORY >
-    // system-wide /run/credentials/@system/ (see systemd.system-credentials(7))
+    // Priority: explicit CLI > /etc config > $CREDENTIALS_DIRECTORY
+    // (ImportCredential= in the unit file handles system-wide credentials)
     let authorized_keys_path = cli_authorized_keys
         .or_else(|| exists(&root.join("etc/varlink-httpd/authorized_keys")))
         .or_else(|| {
@@ -222,12 +222,6 @@ pub(crate) fn maybe_create_ssh_authenticator(
                     .iter()
                     .find_map(|name| exists(&d.join(name)))
             })
-        })
-        .or_else(|| {
-            let sys_creds = root.join("run/credentials/@system");
-            SSH_AUTHORIZED_KEYS_CREDENTIALS
-                .iter()
-                .find_map(|name| exists(&sys_creds.join(name)))
         });
 
     let Some(ak_path) = authorized_keys_path else {

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1669,62 +1669,36 @@ mod sshauth_tests {
             .unwrap();
         assert_eq!(auth.key_count(), 1, "should find key from /etc path");
 
-        // 3. rootdir/run/credentials/@system/ssh.authorized_keys.root exists → found
-        let root_run = tempfile::tempdir().unwrap();
-        let run_dir = root_run.path().join("run/credentials/@system");
-        std::fs::create_dir_all(&run_dir).unwrap();
-        std::fs::write(
-            run_dir.join("ssh.authorized_keys.root"),
-            pubkey_a.as_bytes(),
-        )
-        .unwrap();
-        let auth = maybe_create_ssh_authenticator(None, None, root_run.path())
-            .unwrap()
-            .unwrap();
-        assert_eq!(auth.key_count(), 1, "should find key from /run path");
-
-        // 4. Both /etc and /run exist → /etc takes priority (1 key vs 2 keys)
-        let root_both = tempfile::tempdir().unwrap();
-        let etc_dir = root_both.path().join("etc/varlink-httpd");
-        std::fs::create_dir_all(&etc_dir).unwrap();
-        std::fs::write(etc_dir.join("authorized_keys"), pubkey_a.as_bytes()).unwrap();
-        let run_dir = root_both.path().join("run/credentials/@system");
-        std::fs::create_dir_all(&run_dir).unwrap();
-        let mut run_file = std::fs::File::create(run_dir.join("ssh.authorized_keys.root")).unwrap();
-        writeln!(run_file, "{}", pubkey_b1.trim()).unwrap();
-        writeln!(run_file, "{}", pubkey_b2.trim()).unwrap();
-        drop(run_file);
-        let auth = maybe_create_ssh_authenticator(None, None, root_both.path())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            auth.key_count(),
-            1,
-            "/etc (1 key) should take priority over /run (2 keys)"
-        );
-
-        // 5. $CREDENTIALS_DIRECTORY takes priority over /run
+        // 3. $CREDENTIALS_DIRECTORY/ssh.authorized_keys.root exists → found
         let creds_dir = tempfile::tempdir().unwrap();
         std::fs::write(
             creds_dir.path().join("ssh.authorized_keys.root"),
             pubkey_a.as_bytes(),
         )
         .unwrap();
-        let root_with_run_only = tempfile::tempdir().unwrap();
-        let run_dir = root_with_run_only.path().join("run/credentials/@system");
-        std::fs::create_dir_all(&run_dir).unwrap();
-        let mut run_file = std::fs::File::create(run_dir.join("ssh.authorized_keys.root")).unwrap();
-        writeln!(run_file, "{}", pubkey_b1.trim()).unwrap();
-        writeln!(run_file, "{}", pubkey_b2.trim()).unwrap();
-        drop(run_file);
-        let auth =
-            maybe_create_ssh_authenticator(None, Some(creds_dir.path()), root_with_run_only.path())
-                .unwrap()
-                .unwrap();
+        let auth = maybe_create_ssh_authenticator(None, Some(creds_dir.path()), empty_root.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(auth.key_count(), 1, "should find key from creds_dir");
+
+        // 4. Both /etc and $CREDENTIALS_DIRECTORY exist → /etc takes priority
+        let root_both = tempfile::tempdir().unwrap();
+        let etc_dir = root_both.path().join("etc/varlink-httpd");
+        std::fs::create_dir_all(&etc_dir).unwrap();
+        std::fs::write(etc_dir.join("authorized_keys"), pubkey_a.as_bytes()).unwrap();
+        let creds_dir_b = tempfile::tempdir().unwrap();
+        let mut creds_file =
+            std::fs::File::create(creds_dir_b.path().join("ssh.authorized_keys.root")).unwrap();
+        writeln!(creds_file, "{}", pubkey_b1.trim()).unwrap();
+        writeln!(creds_file, "{}", pubkey_b2.trim()).unwrap();
+        drop(creds_file);
+        let auth = maybe_create_ssh_authenticator(None, Some(creds_dir_b.path()), root_both.path())
+            .unwrap()
+            .unwrap();
         assert_eq!(
             auth.key_count(),
             1,
-            "creds_dir (1 key) should take priority over /run (2 keys)"
+            "/etc (1 key) should take priority over creds_dir (2 keys)"
         );
 
         // 5b. ssh.ephemeral-authorized_keys-all is used when .root is absent (creds_dir)
@@ -1766,24 +1740,6 @@ mod sshauth_tests {
             auth.key_count(),
             1,
             ".root (1 key) should take priority over .all (2 keys)"
-        );
-
-        // 5d. ssh.ephemeral-authorized_keys-all in /run/credentials/@system
-        let root_run_all = tempfile::tempdir().unwrap();
-        let run_dir = root_run_all.path().join("run/credentials/@system");
-        std::fs::create_dir_all(&run_dir).unwrap();
-        std::fs::write(
-            run_dir.join("ssh.ephemeral-authorized_keys-all"),
-            pubkey_a.as_bytes(),
-        )
-        .unwrap();
-        let auth = maybe_create_ssh_authenticator(None, None, root_run_all.path())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            auth.key_count(),
-            1,
-            "should find key from .all in /run path"
         );
 
         // 6. CLI path overrides everything


### PR DESCRIPTION
The previous commit added `ImportCredential=` for the ssh credentials
and with that we can drop our (unnecessary) manual search for the
credentials. Systemd will DTRT now and puts them into our
`$CREDENTIALS_DIRECTORY` instead.

---

varlink-httpd: cleanup systemd credentials usage/imports

This commit adds a well known systemd-credential for the
varlink-http.tls.* credentials. I.e. it adds support for
- `varlink-httpd.tls.certificate:{cert,key,trust}`

It also adds `ImportCredentials=` for
- `ssh.authorized_keys.root`
- `ssh.ephemeral-authorized_keys-all`
in the service file and also updates the README.
