### PR TITLE
packaging: add simple rpm packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,20 @@ jobs:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v3
       - run: just test
+
+  rpm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: systemd/mkosi@66d51024b7149f40be4702e84275c936373ace97
+      - name: Build RPM
+        run: mkosi
+      - name: Verify RPM contents
+        run: |
+          rpm -qlp mkosi/mkosi.output/varlink-httpd-*.rpm | grep -x /usr/bin/varlink-httpd
+          rpm -qlp mkosi/mkosi.output/varlink-httpd-*.rpm | grep -x /usr/lib/systemd/system/varlink-httpd.service
+          rpm -qlp mkosi/mkosi.output/varlink-httpd-*.rpm | grep -x /etc/varlink-httpd
+          rpm -qlp mkosi/mkosi.output/varlinkctl-http-*.rpm | grep -x /usr/lib/systemd/varlink-bridges/http
+          rpm -qlp mkosi/mkosi.output/varlinkctl-http-*.rpm | grep -x /usr/lib/systemd/varlink-bridges/https
+          rpm -qlp mkosi/mkosi.output/varlinkctl-http-*.rpm | grep -x /usr/lib/systemd/varlink-bridges/ws
+          rpm -qlp mkosi/mkosi.output/varlinkctl-http-*.rpm | grep -x /usr/lib/systemd/varlink-bridges/wss

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
-~
+/mkosi/mkosi.cache
+/mkosi/mkosi.output
+mkosi.tools
+mkosi.tools.manifest
+*.list

--- a/justfile
+++ b/justfile
@@ -1,10 +1,11 @@
 destdir := env("DESTDIR", "")
 prefix := "/usr"
+sysconfdir := env("SYSCONFDIR", "/etc")
 bindir := prefix / "bin"
 unitdir := prefix / "lib/systemd/system"
 bridgedir := prefix / "lib/systemd/varlink-bridges"
 
-install: install_server install_client
+install: install_server install_client install_config
 
 install_server: (build "release")
 	install -Dm755 {{srv_binary}} {{destdir}}{{bindir}}/varlink-httpd
@@ -16,6 +17,9 @@ install_client: (build "release")
 	ln -sf http {{destdir}}{{bridgedir}}/https
 	ln -sf http {{destdir}}{{bridgedir}}/ws
 	ln -sf http {{destdir}}{{bridgedir}}/wss
+
+install_config:
+	install -dm755 {{destdir}}{{sysconfdir}}/varlink-httpd
 
 [private]
 build profile:

--- a/mkosi/mkosi.build.chroot
+++ b/mkosi/mkosi.build.chroot
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+
+rpmbuild \
+    -bb \
+    --noprep \
+    --build-in-place \
+    $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
+    --define "_topdir /var/tmp" \
+    --define "_sourcedir $PWD" \
+    --define "_rpmdir ${BUILDDIR:-$PACKAGEDIR}" \
+    --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+    varlink-httpd.spec
+
+mkdir -p "$SRCDIR"/mkosi/mkosi.output
+cp "${BUILDDIR:-$PACKAGEDIR}"/*.rpm "$SRCDIR"/mkosi/mkosi.output/

--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -1,0 +1,15 @@
+[Distribution]
+Distribution=fedora
+
+[Output]
+Format=none
+
+[Build]
+ToolsTree=default
+BuildSources=..
+CacheDirectory=mkosi.cache
+WithNetwork=yes
+
+[Content]
+Packages=
+        rpm-build

--- a/mkosi/mkosi.prepare
+++ b/mkosi/mkosi.prepare
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+mkosi-chroot \
+    rpmspec \
+    --query \
+    --buildrequires \
+    --define "_topdir /var/tmp" \
+    --define "_sourcedir ." \
+    varlink-httpd.spec |
+        sort --unique |
+        tee /tmp/buildrequires |
+        xargs --delimiter '\n' mkosi-install
+
+until mkosi-chroot \
+    rpmbuild \
+    -bd \
+    --build-in-place \
+    --define "_topdir /var/tmp" \
+    --define "_sourcedir ." \
+    --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+    varlink-httpd.spec
+do
+    EXIT_STATUS=$?
+    if [ $EXIT_STATUS -ne 11 ]; then
+        exit $EXIT_STATUS
+    fi
+
+    mkosi-chroot \
+        rpm \
+        --query \
+        --package \
+        --requires \
+        /var/tmp/SRPMS/*.buildreqs.nosrc.rpm |
+            grep --invert-match '^rpmlib(' |
+            sort --unique >/tmp/dynamic-buildrequires
+
+    sort /tmp/buildrequires /tmp/dynamic-buildrequires |
+        uniq --unique |
+        tee --append /tmp/buildrequires |
+        xargs --delimiter '\n' mkosi-install
+done

--- a/varlink-httpd.spec
+++ b/varlink-httpd.spec
@@ -1,0 +1,73 @@
+# we have "strip = true in Cargo.toml" so we need to undefine this
+%undefine _debugsource_packages
+
+Name:           varlink-httpd
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        HTTP bridge for local varlink services
+
+License:        LGPL-2.1-or-later
+URL:            https://github.com/mvo5/varlink-proxy-rs
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  cargo
+BuildRequires:  rust >= 1.85
+BuildRequires:  just
+BuildRequires:  openssl-devel
+BuildRequires:  pkgconfig
+BuildRequires:  gcc
+BuildRequires:  systemd-rpm-macros
+
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+An HTTP bridge that makes local varlink services available over HTTP
+and WebSocket. The main use case is systemd, so only the subset of
+varlink that systemd needs is supported right now.
+
+It takes a directory with varlink sockets as the argument and serves
+whatever it finds there. Sockets can be added or removed dynamically.
+
+%package -n varlinkctl-http
+Summary:        HTTP/WebSocket transport helper for varlinkctl
+Requires:       systemd >= 260~
+
+%description -n varlinkctl-http
+A bridge helper that lets varlinkctl talk to varlink services over
+HTTP and WebSocket (http://, https://, ws://, wss:// URLs). Install
+into /usr/lib/systemd/varlink-bridges/ so that varlinkctl discovers
+it automatically.
+
+%prep
+%autosetup
+
+%build
+just build release
+
+%install
+DESTDIR=%{buildroot} just install
+
+%post
+%systemd_post varlink-httpd.service
+
+%preun
+%systemd_preun varlink-httpd.service
+
+%postun
+%systemd_postun_with_restart varlink-httpd.service
+
+%files
+%{_bindir}/varlink-httpd
+%{_unitdir}/varlink-httpd.service
+
+%files -n varlinkctl-http
+%{_prefix}/lib/systemd/varlink-bridges/http
+%{_prefix}/lib/systemd/varlink-bridges/https
+%{_prefix}/lib/systemd/varlink-bridges/ws
+%{_prefix}/lib/systemd/varlink-bridges/wss
+
+%changelog
+* Mon Mar 02 2026 Michael Vogt <michael@amutable.com> - 0.1.0-1
+- Initial release

--- a/varlink-httpd.spec
+++ b/varlink-httpd.spec
@@ -47,7 +47,7 @@ it automatically.
 just build release
 
 %install
-DESTDIR=%{buildroot} just install
+DESTDIR=%{buildroot} SYSCONFDIR=%{_sysconfdir} just install
 
 %post
 %systemd_post varlink-httpd.service
@@ -61,6 +61,7 @@ DESTDIR=%{buildroot} just install
 %files
 %{_bindir}/varlink-httpd
 %{_unitdir}/varlink-httpd.service
+%dir %{_sysconfdir}/varlink-httpd
 
 %files -n varlinkctl-http
 %{_prefix}/lib/systemd/varlink-bridges/http


### PR DESCRIPTION
This commit adds simple rpm packaging and a test for the packaging. It does not used packaged dependencies so its not good enough (yet) for fedora inclusion but its a starting point and it makes it easier to use/publish rpms this way.