### PR TITLE
api: new endpoint to dynamically generate openapi from varlink IDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ in the dir as needed.
 
 ```
 POST /call/{method}                    → invoke method (c.f. varlink call, supports ?socket=)
+POST /call/{socket}/{method}           → invoke method on an explicitly given socket
 GET  /sockets                          → list available sockets (c.f. valinkctl list-registry)
 GET  /sockets/{socket}                 → socket info (c.f. varlinkctl info)
 GET  /sockets/{socket}/{interface}     → interface details, including method names (c.f. varlinkctl list-methods)
+GET  /openapi/{socket}/{interface}     → OpenAPI 3.1 description generated from varlink IDL
 
 GET  /health                           → health check
 ```
 
-For `/call`, the socket is derived from the method name by stripping
-the last `.Component` (e.g. `io.systemd.Hostname.Describe` connects
-to socket `io.systemd.Hostname`). The `?socket=` query parameter
-overrides this for cross-interface calls, e.g. to call
+For `/call/{method}`, the socket is derived from the method name by
+stripping the last `.Component` (e.g. `io.systemd.Hostname.Describe`
+connects to socket `io.systemd.Hostname`). The `?socket=` query
+parameter overrides this for cross-interface calls, e.g. to call
 `io.systemd.service.SetLogLevel` on the `io.systemd.Hostname` socket.
+The `/call/{socket}/{method}` form makes the socket explicit instead;
+this is the form the generated OpenAPI descriptions use.
 
 For `/call` the parameters are POSTed as regular JSON.
 

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -38,6 +38,7 @@ use zlink::varlink_service::Proxy;
 mod auth_ssh;
 #[cfg(feature = "sshauth")]
 mod import_ssh;
+mod openapi;
 mod ws_framing;
 
 use ws_framing::VarlinkFramer;
@@ -660,6 +661,64 @@ struct AppState {
     authenticators: Arc<Vec<Box<dyn Authenticator>>>,
 }
 
+/// The IDL of one interface, as fetched from a varlink socket.
+///
+/// A parsed [`zlink::idl::Interface`] borrows from the IDL text, so fetching
+/// and parsing cannot collapse into a single call. Holding the unparsed text
+/// in its own type keeps the two halves and their error mapping together.
+struct InterfaceIdl(zlink::varlink_service::InterfaceDescription<'static>);
+
+impl InterfaceIdl {
+    /// Fetch the IDL of `interface` from `socket`.
+    ///
+    /// The connection guard is dropped before returning: the IDL is owned, so
+    /// parsing it needs no connection and must not keep other callers of the
+    /// same socket waiting.
+    async fn fetch(
+        socket: &str,
+        interface: &str,
+        state: &AppState,
+        conn_cache: &VarlinkConnCache,
+    ) -> Result<Self, AppError> {
+        let conn_arc = get_varlink_connection(socket, state, conn_cache).await?;
+        let mut connection = conn_arc.lock().await;
+
+        let description = connection
+            .get_interface_description(interface)
+            .await?
+            .map_err(|e| AppError::bad_gateway(format!("service error: {e}")))?;
+        Ok(Self(description))
+    }
+
+    fn parse(&self) -> Result<zlink::idl::Interface<'_>, AppError> {
+        self.0
+            .parse()
+            .map_err(|e| AppError::bad_gateway(format!("upstream IDL parse error: {e}")))
+    }
+}
+
+async fn route_openapi_get(
+    ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
+    Path((socket, interface)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<axum::Json<Value>, AppError> {
+    debug!("GET openapi for socket: {socket}, interface: {interface}");
+    let idl = InterfaceIdl::fetch(&socket, &interface, &state, &conn_cache).await?;
+    let iface = idl.parse()?;
+
+    // the title and every generated path come from the returned description,
+    // so a service that ignores the requested name would hand out a document
+    // for a different API with nothing to indicate it
+    if iface.name() != interface {
+        return Err(AppError::bad_gateway(format!(
+            "upstream described interface '{}' but '{interface}' was requested",
+            iface.name()
+        )));
+    }
+
+    Ok(axum::Json(openapi::idl_to_openapi(&socket, &iface)))
+}
+
 async fn route_sockets_get(State(state): State<AppState>) -> Result<axum::Json<Value>, AppError> {
     debug!("GET sockets");
     let all_sockets = state.varlink_sockets.list_sockets().await?;
@@ -688,17 +747,8 @@ async fn route_socket_interface_get(
     State(state): State<AppState>,
 ) -> Result<axum::Json<Value>, AppError> {
     debug!("GET socket: {socket}, interface: {interface}");
-    let conn_arc = get_varlink_connection(&socket, &state, &conn_cache).await?;
-    let mut connection = conn_arc.lock().await;
-
-    let description = connection
-        .get_interface_description(&interface)
-        .await?
-        .map_err(|e| AppError::bad_gateway(format!("service error: {e}")))?;
-
-    let iface = description
-        .parse()
-        .map_err(|e| AppError::bad_gateway(format!("upstream IDL parse error: {e}")))?;
+    let idl = InterfaceIdl::fetch(&socket, &interface, &state, &conn_cache).await?;
+    let iface = idl.parse()?;
 
     let method_names: Vec<&str> = iface.methods().map(zlink::idl::Method::name).collect();
     Ok(axum::Json(json!({"method_names": method_names})))
@@ -741,11 +791,48 @@ fn varlink_call_to_jsonseq(
         .unwrap()
 }
 
-/// Call a varlink method.
+/// Call a varlink method on the given socket.
 ///
 /// - Default: single JSON response via varlink `call`
 /// - `Accept: application/json-seq`: stream replies via varlink `more`
 ///   as a JSON text sequence (RFC 7464)
+async fn call_varlink_method(
+    socket: &str,
+    method: &str,
+    state: &AppState,
+    conn_cache: &VarlinkConnCache,
+    headers: &axum::http::HeaderMap,
+    call_args: &HashMap<String, Value>,
+) -> Result<Response, AppError> {
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    let method_call = DynMethod {
+        method,
+        parameters: Some(call_args),
+    };
+
+    let conn_arc = get_varlink_connection(socket, state, conn_cache).await?;
+    let mut connection = conn_arc.lock_owned().await;
+    if accept.contains("application/json-seq") {
+        connection
+            .send_call(&zlink::Call::new(&method_call).set_more(true), vec![])
+            .await?;
+        Ok(varlink_call_to_jsonseq(connection))
+    } else {
+        connection
+            .call_method::<_, DynReply, DynReplyError>(&method_call.into(), vec![])
+            .await?
+            .0
+            .map(|r| r.into_parameters().unwrap_or_default().into_response())
+            .map_err(AppError::from)
+    }
+}
+
+/// Call a varlink method, deriving the socket from the method's
+/// interface prefix unless overridden via `?socket=`.
 async fn route_call_post(
     ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
     Path(method): Path<String>,
@@ -770,31 +857,30 @@ async fn route_call_post(
             .to_string()
     };
 
-    let accept = headers
-        .get(axum::http::header::ACCEPT)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or_default();
+    call_varlink_method(&socket, &method, &state, &conn_cache, &headers, &call_args).await
+}
 
-    let method_call = DynMethod {
-        method: &method,
-        parameters: Some(&call_args),
-    };
+/// Call a varlink method with the socket given explicitly in the path.
+/// This is the form the generated `OpenAPI` documents use.
+async fn route_call_socket_post(
+    ConnectInfo(conn_cache): ConnectInfo<VarlinkConnCache>,
+    Path((socket, method)): Path<(String, String)>,
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    axum::Json(call_args): axum::Json<HashMap<String, Value>>,
+) -> Result<Response, AppError> {
+    debug!("POST call for socket: {socket}, method: {method}");
 
-    let conn_arc = get_varlink_connection(&socket, &state, &conn_cache).await?;
-    let mut connection = conn_arc.lock_owned().await;
-    if accept.contains("application/json-seq") {
-        connection
-            .send_call(&zlink::Call::new(&method_call).set_more(true), vec![])
-            .await?;
-        Ok(varlink_call_to_jsonseq(connection))
-    } else {
-        connection
-            .call_method::<_, DynReply, DynReplyError>(&method_call.into(), vec![])
-            .await?
-            .0
-            .map(|r| r.into_parameters().unwrap_or_default().into_response())
-            .map_err(AppError::from)
+    // `?socket=` is the override for the other /call route and has no meaning
+    // here; accepting it would suggest it does something
+    if params.contains_key("socket") {
+        return Err(AppError::bad_request(
+            "?socket= is not supported here, the socket is already given in the path",
+        ));
     }
+
+    call_varlink_method(&socket, &method, &state, &conn_cache, &headers, &call_args).await
 }
 
 async fn route_ws(
@@ -918,7 +1004,9 @@ fn create_router(
             "/sockets/{socket}/{interface}",
             get(route_socket_interface_get),
         )
+        .route("/openapi/{socket}/{interface}", get(route_openapi_get))
         .route("/call/{method}", post(route_call_post))
+        .route("/call/{socket}/{method}", post(route_call_socket_post))
         .route("/ws/sockets/{socket}", get(route_ws))
         .layer(axum::middleware::from_fn_with_state(
             shared_state.clone(),

--- a/src/bin/varlink-httpd/openapi.rs
+++ b/src/bin/varlink-httpd/openapi.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+use log::warn;
+use serde_json::{Value, json};
+use zlink::idl::{Comment, CustomType, EnumVariant, Field, Interface, Type};
+
+/// Widen a schema to also accept JSON `null`.
+///
+/// varlink services send an explicit `null` for an unset `?T` field rather
+/// than omitting the key, so a schema that only drops the field from
+/// `required` still rejects every real reply.
+fn make_nullable(schema: Value) -> Value {
+    let Value::Object(mut map) = schema else {
+        return schema;
+    };
+    // the empty schema (`any`) already accepts null
+    if map.is_empty() {
+        return Value::Object(map);
+    }
+    match map.get("type") {
+        Some(Value::String(ty)) => {
+            let ty = ty.clone();
+            map.insert("type".to_string(), json!([ty, "null"]));
+            // a value must still be listed in `enum` to validate, so the
+            // widened type alone would not admit null
+            if let Some(Value::Array(variants)) = map.get_mut("enum") {
+                variants.push(Value::Null);
+            }
+            Value::Object(map)
+        }
+        // `$ref` siblings are ignored by many validators, so null has to be
+        // expressed as an alternative rather than an extra type
+        _ => json!({"anyOf": [Value::Object(map), {"type": "null"}]}),
+    }
+}
+
+fn type_to_schema(ty: &Type) -> Value {
+    match ty {
+        Type::Bool => json!({"type": "boolean"}),
+        Type::Int => json!({"type": "integer", "format": "int64"}),
+        Type::Float => json!({"type": "number"}),
+        Type::String => json!({"type": "string"}),
+        Type::ForeignObject => json!({"type": "object"}),
+        // `any` is any JSON value, not just an object
+        Type::Any => json!({}),
+        Type::Custom(name) => {
+            json!({"$ref": format!("#/components/schemas/{name}")})
+        }
+        Type::Optional(inner) => make_nullable(type_to_schema(inner.inner())),
+        Type::Array(inner) => {
+            json!({"type": "array", "items": type_to_schema(inner.inner())})
+        }
+        Type::Map(inner) => {
+            json!({"type": "object", "additionalProperties": type_to_schema(inner.inner())})
+        }
+        Type::Object(fields) => fields_to_schema(fields.iter()),
+        Type::Enum(variants) => {
+            let names: Vec<&str> = variants.iter().map(EnumVariant::name).collect();
+            json!({"type": "string", "enum": names})
+        }
+    }
+}
+
+fn fields_to_schema<'a>(fields: impl Iterator<Item = &'a Field<'a>>) -> Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for field in fields {
+        let mut schema = type_to_schema(field.ty());
+        set_description(&mut schema, comments_to_string(field.comments()));
+        properties.insert(field.name().to_string(), schema);
+        if !matches!(field.ty(), Type::Optional(_)) {
+            required.push(json!(field.name()));
+        }
+    }
+
+    let mut schema = serde_json::Map::new();
+    schema.insert("type".to_string(), json!("object"));
+    schema.insert("properties".to_string(), Value::Object(properties));
+    if !required.is_empty() {
+        schema.insert("required".to_string(), Value::Array(required));
+    }
+    Value::Object(schema)
+}
+
+fn comments_to_string<'a>(comments: impl Iterator<Item = &'a Comment<'a>>) -> Option<String> {
+    let parts: Vec<&str> = comments.map(Comment::content).collect();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+fn set_description(schema: &mut Value, desc: Option<String>) {
+    if let Some(desc) = desc
+        && let Value::Object(map) = schema
+    {
+        map.insert("description".to_string(), json!(desc));
+    }
+}
+
+/// systemd's IDL comment convention for the `more` flag: a marker on
+/// its own doc comment line. systemd itself relies on the exact
+/// wording, so it is stable.
+const SUPPORTS_MORE_MARKER: &str = "[Supports 'more' flag]";
+const REQUIRES_MORE_MARKER: &str = "[Requires 'more' flag]";
+
+/// How a method relates to varlink's `more` flag, derived from the
+/// systemd IDL comment convention.
+enum MoreFlag {
+    /// No `more` support, single JSON response only.
+    None,
+    /// [`SUPPORTS_MORE_MARKER`]: client may optionally use `more: true`.
+    Supports,
+    /// [`REQUIRES_MORE_MARKER`]: client must use `more: true`.
+    Requires,
+}
+
+/// Whole-line match, so prose that merely mentions a marker is not treated
+/// as one.
+fn is_more_marker(comment: &Comment) -> bool {
+    matches!(
+        comment.content().trim(),
+        SUPPORTS_MORE_MARKER | REQUIRES_MORE_MARKER
+    )
+}
+
+fn method_more_flag(method: &zlink::idl::Method) -> MoreFlag {
+    for c in method.comments() {
+        match c.content().trim() {
+            REQUIRES_MORE_MARKER => return MoreFlag::Requires,
+            SUPPORTS_MORE_MARKER => return MoreFlag::Supports,
+            _ => {}
+        }
+    }
+    MoreFlag::None
+}
+
+/// Note attached to the response of a method that can stream.
+///
+/// This belongs on the Response Object: the OAS 3.1 meta-schema forbids
+/// unknown keys (`description` among them) inside a Media Type Object.
+const JSON_SEQ_NOTE: &str = "Streaming replies use the varlink 'more' flag: \
+     request them with Accept: application/json-seq and each reply arrives as \
+     an RFC 7464 JSON text sequence record (RS 0x1E + JSON + LF).";
+
+pub fn idl_to_openapi(address: &str, iface: &Interface) -> Value {
+    let mut paths = serde_json::Map::new();
+
+    for method in iface.methods() {
+        let full_method = format!("{}.{}", iface.name(), method.name());
+        let path = format!("/call/{address}/{full_method}");
+
+        let mut operation = serde_json::Map::new();
+        // the fully qualified name stays unique when documents for several
+        // interfaces of one socket are fed to a single codegen run
+        operation.insert("operationId".to_string(), json!(full_method));
+        // the marker lines are a varlink-side convention; over HTTP the same
+        // information is already carried by the response content types
+        if let Some(desc) = comments_to_string(method.comments().filter(|c| !is_more_marker(c))) {
+            operation.insert("description".to_string(), json!(desc));
+        }
+        operation.insert(
+            "requestBody".to_string(),
+            json!({
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": fields_to_schema(method.inputs())
+                    }
+                }
+            }),
+        );
+        let output_schema = fields_to_schema(method.outputs());
+        let more_flag = method_more_flag(method);
+
+        let mut content = serde_json::Map::new();
+        if !matches!(more_flag, MoreFlag::Requires) {
+            content.insert(
+                "application/json".to_string(),
+                json!({"schema": output_schema.clone()}),
+            );
+        }
+        if !matches!(more_flag, MoreFlag::None) {
+            content.insert(
+                "application/json-seq".to_string(),
+                json!({"schema": output_schema}),
+            );
+        }
+
+        let response_description = match more_flag {
+            MoreFlag::None => "Successful response".to_string(),
+            _ => format!("Successful response\n\n{JSON_SEQ_NOTE}"),
+        };
+
+        operation.insert(
+            "responses".to_string(),
+            json!({
+                "200": {
+                    "description": response_description,
+                    "content": Value::Object(content)
+                }
+            }),
+        );
+
+        let path_item = json!({ "post": Value::Object(operation) });
+        if paths.insert(path, path_item).is_some() {
+            warn!(
+                "{}: duplicate method '{}' in upstream IDL, only the last is described",
+                iface.name(),
+                method.name()
+            );
+        }
+    }
+
+    let mut schemas = serde_json::Map::new();
+
+    for custom_type in iface.custom_types() {
+        let (mut schema, desc) = match custom_type {
+            CustomType::Object(obj) => (
+                fields_to_schema(obj.fields()),
+                comments_to_string(obj.comments()),
+            ),
+            CustomType::Enum(e) => {
+                let names: Vec<&str> = e.variants().map(EnumVariant::name).collect();
+                (
+                    json!({"type": "string", "enum": names}),
+                    comments_to_string(e.comments()),
+                )
+            }
+        };
+        set_description(&mut schema, desc);
+        schemas.insert(custom_type.name().to_string(), schema);
+    }
+
+    for error in iface.errors() {
+        let mut schema = fields_to_schema(error.fields());
+        set_description(&mut schema, comments_to_string(error.comments()));
+        // varlink keeps type and error names apart, OpenAPI does not, so a
+        // name used by both would silently resolve to whichever landed last
+        if schemas.insert(error.name().to_string(), schema).is_some() {
+            warn!(
+                "{}: error '{}' shadows a type of the same name in components/schemas",
+                iface.name(),
+                error.name()
+            );
+        }
+    }
+
+    let mut doc = json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": iface.name(),
+            "version": "0.0.0",
+        },
+        "paths": paths,
+    });
+
+    set_description(&mut doc["info"], comments_to_string(iface.comments()));
+
+    if !schemas.is_empty() {
+        doc["components"] = json!({ "schemas": schemas });
+    }
+
+    doc
+}

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -156,6 +156,10 @@ async fn run_test_server_with_auth(
     varlink_sockets_path: &str,
     authenticators: Vec<Box<dyn Authenticator>>,
 ) -> TestServer<std::net::SocketAddr> {
+    // the logger is process-global and installed once, so leaving it to
+    // individual tests makes debug output depend on execution order
+    init_test_logger();
+
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind to random port failed");
@@ -176,6 +180,19 @@ async fn run_test_server_with_auth(
     });
 
     TestServer { handle, addr }
+}
+
+/// GET the generated `OpenAPI` document for `socket`/`interface`.
+async fn fetch_openapi(addr: std::net::SocketAddr, socket: &str, interface: &str) -> Value {
+    let res = Client::new()
+        .get(format!("http://{addr}/openapi/{socket}/{interface}"))
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("failed to get openapi for {socket}/{interface}: {e}"));
+    assert_eq!(res.status(), 200, "GET openapi for {socket}/{interface}");
+    res.json()
+        .await
+        .unwrap_or_else(|e| panic!("invalid openapi json for {socket}/{interface}: {e}"))
 }
 
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
@@ -561,6 +578,56 @@ async fn test_varlink_unix_sockets_in_skips_dangling_symlinks() {
         .await
         .expect("list_sockets should not fail on dangling symlinks");
     assert_eq!(sockets, vec!["io.systemd.Hostname"]);
+}
+
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_integration_real_systemd_openapi_get() {
+    let server = run_test_server("/run/systemd").await;
+
+    let body = fetch_openapi(server.addr, "io.systemd.Hostname", "io.systemd.Hostname").await;
+    assert_eq!(body["openapi"], "3.1.0");
+    assert!(body.get("paths").is_some(), "missing 'paths' key");
+    assert!(body.get("info").is_some(), "missing 'info' key");
+    assert_eq!(body["info"]["title"], "io.systemd.Hostname");
+}
+
+// Guards against the generated document and the router drifting apart:
+// every documented path must be served (may fail for other reasons, but
+// never 404), and calling a documented method must work end to end.
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_integration_openapi_paths_are_routable() {
+    let server = run_test_server("/run/systemd").await;
+
+    let client = Client::new();
+    let doc = fetch_openapi(server.addr, "io.systemd.Hostname", "io.systemd.Hostname").await;
+
+    let paths = doc["paths"].as_object().expect("missing 'paths' object");
+    for path in paths.keys() {
+        let res = client
+            .post(format!("http://{}{path}", server.addr))
+            .json(&json!({}))
+            .send()
+            .await
+            .expect("failed to post to documented path");
+        assert_ne!(res.status(), 404, "documented path '{path}' is not routed");
+    }
+
+    let describe_path = "/call/io.systemd.Hostname/io.systemd.Hostname.Describe";
+    assert!(
+        paths.contains_key(describe_path),
+        "expected '{describe_path}' in generated paths"
+    );
+    let res = client
+        .post(format!("http://{}{describe_path}", server.addr))
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("failed to post to documented Describe path");
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.expect("varlink body invalid");
+    assert!(body["Hostname"].as_str().is_some_and(|h| !h.is_empty()));
 }
 
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
@@ -1990,3 +2057,374 @@ mod sshauth_tests {
         assert_hostname_reply(&output);
     }
 } // mod sshauth_tests
+
+// A varlink IDL that exercises all type features: methods with typed
+// input/output, a struct typedef, an enum typedef, an error with
+// parameters, arrays, dicts, optionals, and doc strings.
+const TEST_IDL: &str = "\
+# A test interface
+interface com.example.test
+
+# Status values
+type Status (enabled: bool, tag: ?string)
+
+# Priority levels
+type Priority (low, medium, high)
+
+# Item not found
+error ItemNotFound (id: int)
+
+# Get an item by id
+method GetItem(
+  # The item identifier
+  id: int,
+  options: ?object
+) -> (
+  name: string,
+  score: float,
+  status: Status,
+  tags: []string,
+  metadata: [string]int,
+  mode: (on, off, auto)
+)
+
+# List all items
+# [Supports 'more' flag]
+method ListItems() -> (
+  name: string,
+  id: int
+)
+
+# Watch for item changes
+# [Requires 'more' flag]
+method WatchItems() -> (
+  name: string,
+  event: string
+)
+
+# Count items. Unlike WatchItems this does not use [Requires 'more' flag].
+method CountItems() -> (count: int)
+";
+
+#[test]
+fn test_idl_to_openapi() {
+    let iface: zlink::idl::Interface = TEST_IDL.try_into().expect("failed to parse test IDL");
+    let doc = openapi::idl_to_openapi("com.example.test", &iface);
+
+    // top-level structure
+    assert_eq!(doc["openapi"], "3.1.0");
+    assert_eq!(doc["info"]["title"], "com.example.test");
+    assert_eq!(doc["info"]["version"], "0.0.0");
+    assert_eq!(doc["info"]["description"], "A test interface");
+
+    // paths - one POST for GetItem
+    let path = &doc["paths"]["/call/com.example.test/com.example.test.GetItem"];
+    assert!(path.is_object(), "missing path for GetItem");
+    let post = &path["post"];
+    assert_eq!(post["operationId"], "com.example.test.GetItem");
+    assert_eq!(post["description"], "Get an item by id");
+
+    // request body schema
+    let req_schema = &post["requestBody"]["content"]["application/json"]["schema"];
+    assert_eq!(req_schema["type"], "object");
+    assert_eq!(req_schema["properties"]["id"]["type"], "integer");
+    assert_eq!(req_schema["properties"]["id"]["format"], "int64");
+    assert_eq!(
+        req_schema["properties"]["id"]["description"],
+        "The item identifier"
+    );
+    // `?object` accepts null as well as an object
+    assert_eq!(
+        req_schema["properties"]["options"]["type"],
+        json!(["object", "null"])
+    );
+    // "id" is required, "options" is optional
+    let required: Vec<&str> = req_schema["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(required.contains(&"id"));
+    assert!(!required.contains(&"options"));
+
+    // response schema: GetItem does NOT support 'more', so no json-seq
+    let resp_content = &post["responses"]["200"]["content"];
+    assert!(
+        resp_content.get("application/json-seq").is_none(),
+        "GetItem should not have json-seq response (no 'more' flag)"
+    );
+    let resp_schema = &resp_content["application/json"]["schema"];
+    assert_eq!(resp_schema["properties"]["name"]["type"], "string");
+    assert_eq!(resp_schema["properties"]["score"]["type"], "number");
+    assert_eq!(
+        resp_schema["properties"]["status"]["$ref"],
+        "#/components/schemas/Status"
+    );
+    // array type
+    assert_eq!(resp_schema["properties"]["tags"]["type"], "array");
+    assert_eq!(resp_schema["properties"]["tags"]["items"]["type"], "string");
+    // dict type
+    assert_eq!(resp_schema["properties"]["metadata"]["type"], "object");
+    assert_eq!(
+        resp_schema["properties"]["metadata"]["additionalProperties"]["type"],
+        "integer"
+    );
+    // inline enum type
+    assert_eq!(resp_schema["properties"]["mode"]["type"], "string");
+    assert_eq!(
+        resp_schema["properties"]["mode"]["enum"],
+        json!(["on", "off", "auto"])
+    );
+
+    // components/schemas - struct typedef
+    let status_schema = &doc["components"]["schemas"]["Status"];
+    assert_eq!(status_schema["type"], "object");
+    assert_eq!(status_schema["description"], "Status values");
+    assert_eq!(status_schema["properties"]["enabled"]["type"], "boolean");
+    assert_eq!(
+        status_schema["properties"]["tag"]["type"],
+        json!(["string", "null"])
+    );
+    // "enabled" required, "tag" optional
+    let status_required: Vec<&str> = status_schema["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(status_required.contains(&"enabled"));
+    assert!(!status_required.contains(&"tag"));
+
+    // components/schemas - enum typedef
+    let priority_schema = &doc["components"]["schemas"]["Priority"];
+    assert_eq!(priority_schema["type"], "string");
+    assert_eq!(priority_schema["description"], "Priority levels");
+    assert_eq!(priority_schema["enum"], json!(["low", "medium", "high"]));
+
+    // components/schemas - error
+    let error_schema = &doc["components"]["schemas"]["ItemNotFound"];
+    assert_eq!(error_schema["type"], "object");
+    assert_eq!(error_schema["description"], "Item not found");
+    assert_eq!(error_schema["properties"]["id"]["type"], "integer");
+    assert_eq!(error_schema["properties"]["id"]["format"], "int64");
+}
+
+#[test]
+fn test_idl_to_openapi_more_flag() {
+    let iface: zlink::idl::Interface = TEST_IDL.try_into().expect("failed to parse test IDL");
+    let doc = openapi::idl_to_openapi("com.example.test", &iface);
+
+    // ListItems supports 'more', should have both json and json-seq responses
+    let list_path = &doc["paths"]["/call/com.example.test/com.example.test.ListItems"];
+    assert!(list_path.is_object(), "missing path for ListItems");
+    let list_post = &list_path["post"];
+    assert_eq!(list_post["operationId"], "com.example.test.ListItems");
+    // the marker line is stripped from the prose description
+    assert_eq!(list_post["description"], "List all items");
+    let list_resp = &list_post["responses"]["200"]["content"];
+    assert!(
+        list_resp["application/json"]["schema"].is_object(),
+        "ListItems should have json response"
+    );
+    // the streaming note belongs on the Response Object; a Media Type Object
+    // may not carry a description
+    assert!(
+        list_post["responses"]["200"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("RFC 7464"),
+        "streaming response should document RFC 7464 on the response object"
+    );
+    for media_type in ["application/json", "application/json-seq"] {
+        let keys: Vec<&String> = list_resp[media_type].as_object().unwrap().keys().collect();
+        assert_eq!(
+            keys,
+            vec!["schema"],
+            "{media_type} media type object must only carry 'schema'"
+        );
+    }
+    assert_eq!(
+        list_resp["application/json-seq"]["schema"], list_resp["application/json"]["schema"],
+        "json-seq and json schemas should match"
+    );
+
+    // WatchItems uses [Requires 'more' flag], should have ONLY json-seq
+    let watch_path = &doc["paths"]["/call/com.example.test/com.example.test.WatchItems"];
+    assert!(watch_path.is_object(), "missing path for WatchItems");
+    let watch_resp = &watch_path["post"]["responses"]["200"]["content"];
+    assert!(
+        watch_resp["application/json-seq"].is_object(),
+        "WatchItems should have json-seq response ([Requires 'more' flag])"
+    );
+    assert!(
+        watch_resp.get("application/json").is_none(),
+        "WatchItems should NOT have plain json response ([Requires 'more' flag])"
+    );
+
+    // CountItems only mentions a marker in prose; that must not count
+    // as a marker line
+    let count_path = &doc["paths"]["/call/com.example.test/com.example.test.CountItems"];
+    assert!(count_path.is_object(), "missing path for CountItems");
+    let count_resp = &count_path["post"]["responses"]["200"]["content"];
+    assert!(
+        count_resp["application/json"]["schema"].is_object(),
+        "CountItems should have json response (marker only mentioned in prose)"
+    );
+    assert!(
+        count_resp.get("application/json-seq").is_none(),
+        "CountItems should NOT have json-seq response (marker only mentioned in prose)"
+    );
+}
+
+// Optional fields arrive as an explicit JSON null rather than a missing key,
+// so every `?T` has to widen to accept null.
+const NULLABLE_IDL: &str = "\
+interface com.example.nullable
+
+type Inner (a: int)
+
+method Get() -> (
+  plain: ?string,
+  custom: ?Inner,
+  choice: ?(on, off),
+  anything: ?any,
+  list: []?string,
+  dict: [string]?int
+)
+";
+
+#[test]
+fn test_idl_to_openapi_nullable() {
+    let iface: zlink::idl::Interface = NULLABLE_IDL.try_into().expect("failed to parse test IDL");
+    let doc = openapi::idl_to_openapi("com.example.nullable", &iface);
+
+    let props = &doc["paths"]["/call/com.example.nullable/com.example.nullable.Get"]["post"]["responses"]
+        ["200"]["content"]["application/json"]["schema"]["properties"];
+
+    // plain scalar widens its type
+    assert_eq!(props["plain"]["type"], json!(["string", "null"]));
+
+    // a $ref cannot carry a sibling type, so null becomes an alternative
+    assert_eq!(
+        props["custom"],
+        json!({"anyOf": [{"$ref": "#/components/schemas/Inner"}, {"type": "null"}]})
+    );
+
+    // an enum has to list null as an allowed value too
+    assert_eq!(props["choice"]["type"], json!(["string", "null"]));
+    assert_eq!(props["choice"]["enum"], json!(["on", "off", null]));
+
+    // `any` already accepts null
+    assert_eq!(props["anything"], json!({}));
+
+    // nullability inside containers is preserved
+    assert_eq!(props["list"]["items"]["type"], json!(["string", "null"]));
+    assert_eq!(
+        props["dict"]["additionalProperties"]["type"],
+        json!(["integer", "null"])
+    );
+}
+
+// ?socket= belongs to the other /call route; on the explicit-socket route it
+// is rejected rather than silently ignored, whatever it points at.
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_integration_call_socket_rejects_query_param() {
+    let server = run_test_server("/run/systemd").await;
+    let client = Client::new();
+
+    for socket in ["io.systemd.Login", "io.systemd.Hostname"] {
+        let res = client
+            .post(format!(
+                "http://{}/call/io.systemd.Hostname/io.systemd.Hostname.Describe?socket={socket}",
+                server.addr,
+            ))
+            .json(&json!({}))
+            .send()
+            .await
+            .expect("failed to post to test server");
+        assert_eq!(res.status(), 400, "?socket={socket} should be rejected");
+    }
+
+    // without the query parameter the same call succeeds
+    let res = client
+        .post(format!(
+            "http://{}/call/io.systemd.Hostname/io.systemd.Hostname.Describe",
+            server.addr,
+        ))
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("failed to post to test server");
+    assert_eq!(res.status(), 200);
+}
+
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_integration_openapi_no_more_flag() {
+    let server = run_test_server("/run/varlink/registry").await;
+
+    let res = fetch_openapi(server.addr, "io.systemd.Hostname", "io.systemd.Hostname").await;
+
+    let describe = &res["paths"]["/call/io.systemd.Hostname/io.systemd.Hostname.Describe"]["post"];
+    let content = &describe["responses"]["200"]["content"];
+    assert!(
+        content["application/json"]["schema"].is_object(),
+        "Describe should have json response"
+    );
+    assert!(
+        content.get("application/json-seq").is_none(),
+        "Describe should NOT have json-seq response (no 'more' flag)"
+    );
+}
+
+#[test_with::path(/run/varlink/registry/io.systemd.UserDatabase)]
+#[tokio::test]
+async fn test_integration_openapi_supports_more_flag() {
+    let server = run_test_server("/run/varlink/registry").await;
+
+    let res = fetch_openapi(
+        server.addr,
+        "io.systemd.UserDatabase",
+        "io.systemd.UserDatabase",
+    )
+    .await;
+
+    let get_user = &res["paths"]["/call/io.systemd.UserDatabase/io.systemd.UserDatabase.GetUserRecord"]
+        ["post"];
+    let content = &get_user["responses"]["200"]["content"];
+    assert!(
+        content["application/json"]["schema"].is_object(),
+        "GetUserRecord should have json response (supports 'more')"
+    );
+    assert!(
+        content["application/json-seq"].is_object(),
+        "GetUserRecord should have json-seq response (supports 'more')"
+    );
+}
+
+#[test_with::path(/run/varlink/registry/io.systemd.MachineImage)]
+#[tokio::test]
+async fn test_integration_openapi_requires_more_flag() {
+    let server = run_test_server("/run/varlink/registry").await;
+
+    let res = fetch_openapi(
+        server.addr,
+        "io.systemd.MachineImage",
+        "io.systemd.MachineImage",
+    )
+    .await;
+
+    let clean_pool =
+        &res["paths"]["/call/io.systemd.MachineImage/io.systemd.MachineImage.CleanPool"]["post"];
+    let content = &clean_pool["responses"]["200"]["content"];
+    assert!(
+        content["application/json-seq"].is_object(),
+        "CleanPool should have json-seq response (requires 'more')"
+    );
+    assert!(
+        content.get("application/json").is_none(),
+        "CleanPool should NOT have json response (requires 'more')"
+    );
+}


### PR DESCRIPTION
This commit adds an endpoint for that generates openapi descriptions
from the varlink IDL for a given interface. It is located under
/openapi/{socket}/{interface} and is created dynamically.

This is useful to bridge the gap between varlink and the wide
openapi ecosytem. This allows to e.g. create fully typed interfaces
for tyescript/react/go etc.

This is using openapi 3.1 because it seems to be the most widely
used one currently.

Note that this seems to work well for most of the IDL and it maps
nicely. The thing that does not map well is errors. The varlink
IDL does only specify errors per interface but not per method. So
currently errors are added as `components` but not part of the
potential methods returns because we would have to add all errors
as potential returns to all methods which feels a bit too much.
Nullable is also added a bit simplistic.

To make it easier for webapps this also adds an alternative call
path: `/call/{socket}/{method}` to make it easier for the OpenAPI
clients to use sockets that implement multiple interfaces.

E.g.
```json
$ curl -s http://localhost:1031/openapi/io.systemd.MuteConsole/io.systemd.MuteConsole | jq .
{
  "info": {
    "description": "API for temporarily muting noisy output to the main kernel console",
    "title": "io.systemd.MuteConsole",
    "version": "0.0.0"
  },
  "openapi": "3.1.0",
  "paths": {
    "/call/io.systemd.MuteConsole/io.systemd.MuteConsole.Mute": {
      "post": {
        "description": "Mute kernel and PID 1 output to the main kernel console\n[Requires 'more' flag]",
        "operationId": "Mute",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "properties": {
                  "kernel": {
                    "description": "Whether to mute the kernel's output to the console (defaults to true).",
                    "type": "boolean"
                  },
                  "pid1": {
                    "description": "Whether to mute PID1's output to the console (defaults to true).",
                    "type": "boolean"
                  }
                },
                "type": "object"
              }
            }
          },
          "required": true
        },
        "responses": {
          "200": {
            "content": {
              "application/json-seq": {
                "description": "Streaming response using the varlink 'more' flag. Each reply is encoded as an RFC 7464 JSON text sequence (RS 0x1E + JSON + LF). Request this format via Accept: application/json-seq.",
                "schema": {
                  "properties": {},
                  "type": "object"
                }
              }
            },
            "description": "Successful response"
          }
        }
      }
    }
  }
}
```

