### PR TITLE
httpd: improve error message for methods that requires "more"

### DIFF
--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -73,14 +73,22 @@ impl IntoResponse for AppError {
 impl From<zlink::Error> for AppError {
     fn from(e: zlink::Error) -> Self {
         use zlink::varlink_service;
+        let mut message = None;
         let status = match &e {
             zlink::Error::SocketRead
             | zlink::Error::SocketWrite
             | zlink::Error::UnexpectedEof
             | zlink::Error::Io(..) => StatusCode::BAD_GATEWAY,
             zlink::Error::VarlinkService(owned) => match owned.inner() {
-                varlink_service::Error::InvalidParameter { .. }
-                | varlink_service::Error::ExpectedMore => StatusCode::BAD_REQUEST,
+                varlink_service::Error::InvalidParameter { .. } => StatusCode::BAD_REQUEST,
+                varlink_service::Error::ExpectedMore => {
+                    message = Some(
+                        "This method requires the varlink 'more' flag. \
+                         Use Accept: application/json-seq to enable streaming."
+                            .to_string(),
+                    );
+                    StatusCode::BAD_REQUEST
+                }
                 varlink_service::Error::MethodNotFound { .. }
                 | varlink_service::Error::InterfaceNotFound { .. } => StatusCode::NOT_FOUND,
                 varlink_service::Error::MethodNotImplemented { .. } => StatusCode::NOT_IMPLEMENTED,
@@ -90,7 +98,7 @@ impl From<zlink::Error> for AppError {
         };
         Self {
             status,
-            message: e.to_string(),
+            message: message.unwrap_or(e.to_string()),
         }
     }
 }


### PR DESCRIPTION
When a method is called that requires the "more" flag in varlink we currently only error with BAD_REQUEST - however we can do better and tell the caller more deails what whent wrong. So this commit tweaks the error to return a helpful error string:
```
$ curl -v -X POST \
   http://localhost:1031/call/io.systemd.MachineImage.CleanPool \
   -H 'Content-Type: application/json' -d '{}'
> POST /call/io.systemd.MachineImage.CleanPool HTTP/1.1
> Content-Type: application/json
>
< HTTP/1.1 400 Bad Request
< content-type: application/json
<
{"error":"This method requires the varlink 'more' flag. Use Accept:
application/json-seq to enable streaming."}
```