### PR TITLE
many: add vsock support for the bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,9 @@ regex-lite = "0.1"
 listenfd = "1.0.2"
 tungstenite = "0.29"
 rustix = { version = "1.0", features = ["event", "net", "process"] }
-tokio-vsock = { version = "0.7", features = ["axum08"] }
+# TODO: switch back to crates.io once tokio-vsock releases a version with
+# From<OwnedFd> support (https://github.com/rust-vsock/tokio-vsock/pull/72)
+tokio-vsock = { git = "https://github.com/rust-vsock/tokio-vsock.git", rev = "c6225086", features = ["axum08"] }
 vsock = "0.5"
 signal-hook = "0.4"
 socket2 = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tempfile = { version = "3.27", optional = true }
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }
 test-with = { version = "0.16", default-features = false, features = ["runtime"] }
-scopeguard = "1.2"
 gethostname = "1.1.0"
 tempfile = "3.27"
 tokio-tungstenite = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ lexopt = "0.3"
 regex-lite = "0.1"
 listenfd = "1.0.2"
 tungstenite = "0.29"
-rustix = { version = "1.0", features = ["event", "process"] }
+rustix = { version = "1.0", features = ["event", "net", "process"] }
+tokio-vsock = { version = "0.7", features = ["axum08"] }
+vsock = "0.5"
 signal-hook = "0.4"
 socket2 = "0.6"
 # using opeenssl here to keep size small, rusttls adds ~1.8MB binary size

--- a/README.md
+++ b/README.md
@@ -193,6 +193,49 @@ $ varlink --bridge "websocat --binary ws://localhost:1031/ws/sockets/io.systemd.
 
 ```
 
+## vsock transport
+
+The bridge supports AF_VSOCK as an alternative to TCP, allowing
+host-to-guest communication without a network.
+
+### Server
+
+```console
+# Listen on vsock with default port (1031):
+$ varlink-httpd --bind=vsock --insecure
+
+# Listen on a specific port:
+$ varlink-httpd --bind=vsock::5000 --insecure
+
+# Socket activation (systemd auto-detects AF_VSOCK):
+# [Socket]
+# ListenStream=vsock::1031
+```
+
+### Client
+
+```console
+# Connect to host (CID 2) on default port:
+$ varlinkctl call vsock://2/io.systemd.Hostname/Describe '{}'
+
+# Connect with explicit port:
+$ varlinkctl call vsock://3:5000/io.systemd.Hostname/Describe '{}'
+```
+
+CID 2 is always the host. Guest CIDs (3+) are assigned by the VMM.
+
+### systemd socket activation
+
+A socket-activated unit is provided for VMs. Enable it inside the guest:
+
+```console
+# systemctl enable --now varlink-httpd-vsock.socket
+```
+
+The socket unit uses `ConditionVirtualization=vm`, so it only activates
+inside a VM. On bare metal or the host it is silently skipped. The
+daemon starts on demand when the first vsock connection arrives.
+
 ## TLS / mTLS
 
 TLS flag names follow the systemd convention.

--- a/README.md
+++ b/README.md
@@ -226,15 +226,23 @@ CID 2 is always the host. Guest CIDs (3+) are assigned by the VMM.
 
 ### systemd socket activation
 
-A socket-activated unit is provided for VMs. Enable it inside the guest:
+Two socket units are shipped, both backed by the same
+`varlink-httpd.service`:
+
+- `varlink-httpd.socket` listens on TCP `0.0.0.0:1031`.
+- `varlink-httpd-vsock.socket` listens on `vsock::1031` and has
+  `ConditionVirtualization=vm`, so it only activates inside a VM. On
+  bare metal or the host it is silently skipped, which makes it safe
+  to enable unconditionally.
+
+Enable whichever sockets you want; if both are enabled, systemd passes
+both listening fds to the service on activation, so the daemon listens
+on both transports regardless of which connection arrives first. The
+daemon starts on demand when the first connection arrives.
 
 ```console
-# systemctl enable --now varlink-httpd-vsock.socket
+# systemctl enable --now varlink-httpd.socket varlink-httpd-vsock.socket
 ```
-
-The socket unit uses `ConditionVirtualization=vm`, so it only activates
-inside a VM. On bare metal or the host it is silently skipped. The
-daemon starts on demand when the first vsock connection arrives.
 
 ## TLS / mTLS
 

--- a/README.md
+++ b/README.md
@@ -196,33 +196,44 @@ $ varlink --bridge "websocat --binary ws://localhost:1031/ws/sockets/io.systemd.
 ## vsock transport
 
 The bridge supports AF_VSOCK as an alternative to TCP, allowing
-host-to-guest communication without a network.
+host-to-guest communication without a network. vsock traffic cannot
+be sniffed on the network, but any process on the host can connect
+to a guest's vsock port, so authentication is still required (mTLS
+or SSH key auth).
 
-### Server
+### SSH key auth over vsock
 
-```console
-# Listen on vsock with default port (1031):
-$ varlink-httpd --bind=vsock --insecure
-
-# Listen on a specific port:
-$ varlink-httpd --bind=vsock::5000 --insecure
-
-# Socket activation (systemd auto-detects AF_VSOCK):
-# [Socket]
-# ListenStream=vsock::1031
-```
-
-### Client
+vsock with SSH key auth works without TLS - the transport is not
+sniffable so the lack of encryption is acceptable:
 
 ```console
-# Connect to host (CID 2) on default port:
-$ varlinkctl call vsock://2/io.systemd.Hostname/Describe '{}'
+# Server (inside the guest):
+$ varlink-httpd --bind=vsock --authorized-keys=~/.ssh/authorized_keys
 
-# Connect with explicit port:
-$ varlinkctl call vsock://3:5000/io.systemd.Hostname/Describe '{}'
+# Client (on the host):
+$ varlinkctl call vsock://3/ws/sockets/io.systemd.Hostname \
+    io.systemd.Hostname.Describe '{}'
 ```
 
-CID 2 is always the host. Guest CIDs (3+) are assigned by the VMM.
+### mTLS over vsock
+
+Server (inside the guest):
+
+```console
+$ varlink-httpd --bind=vsock \
+    --cert=server.pem --key=server-key.pem --trust=ca.pem
+```
+
+Client (on the host), using `vsock+tls://`:
+
+```console
+$ varlinkctl call vsock+tls://3/ws/sockets/io.systemd.Hostname \
+    io.systemd.Hostname.Describe '{}'
+```
+
+The client looks for its certificate and key in the same config
+directories as for TCP (see [Client (varlinkctl-http)](#client-varlinkctl-http)
+below). CID 3+ are guests; CID 2 is the host.
 
 ### systemd socket activation
 

--- a/data/varlink-httpd-vsock.socket
+++ b/data/varlink-httpd-vsock.socket
@@ -1,0 +1,15 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of varlink-http-bridge.
+
+[Unit]
+Description=Varlink HTTP Bridge (vsock)
+ConditionVirtualization=vm
+
+[Socket]
+ListenStream=vsock::1031
+FileDescriptorName=vsock
+Service=varlink-httpd.service
+
+[Install]
+WantedBy=sockets.target

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -15,7 +15,7 @@ Conflicts=shutdown.target
 
 [Service]
 Type=simple
-ExecStart=@bindir@/varlink-httpd --bind 0.0.0.0:1031
+ExecStart=@bindir@/varlink-httpd
 Restart=on-failure
 RestartSec=5
 

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -19,6 +19,22 @@ ExecStart=@bindir@/varlink-httpd
 Restart=on-failure
 RestartSec=5
 
+# Hardening
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_VSOCK
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+NoNewPrivileges=yes
+
 # TLS credentials: well-known names from the credstore, renamed to the
 # short names the service expects in $CREDENTIALS_DIRECTORY.
 # Place certs in /etc/credstore/ and keys in /etc/credstore.encrypted/.

--- a/data/varlink-httpd.socket
+++ b/data/varlink-httpd.socket
@@ -1,0 +1,14 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of varlink-http-bridge.
+
+[Unit]
+Description=Varlink HTTP Bridge (TCP)
+
+[Socket]
+ListenStream=0.0.0.0:1031
+FileDescriptorName=tcp
+Service=varlink-httpd.service
+
+[Install]
+WantedBy=sockets.target

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ install_server: (build "release")
 	install -Dm755 {{srv_binary}} {{destdir}}{{bindir}}/varlink-httpd
 	install -dm755 {{destdir}}{{unitdir}}
 	sed 's|@bindir@|{{bindir}}|g' data/varlink-httpd.service.in > {{destdir}}{{unitdir}}/varlink-httpd.service
+	install -m644 data/varlink-httpd.socket {{destdir}}{{unitdir}}/varlink-httpd.socket
 	install -m644 data/varlink-httpd-vsock.socket {{destdir}}{{unitdir}}/varlink-httpd-vsock.socket
 
 install_client: (build "release")

--- a/justfile
+++ b/justfile
@@ -11,12 +11,14 @@ install_server: (build "release")
 	install -Dm755 {{srv_binary}} {{destdir}}{{bindir}}/varlink-httpd
 	install -dm755 {{destdir}}{{unitdir}}
 	sed 's|@bindir@|{{bindir}}|g' data/varlink-httpd.service.in > {{destdir}}{{unitdir}}/varlink-httpd.service
+	install -m644 data/varlink-httpd-vsock.socket {{destdir}}{{unitdir}}/varlink-httpd-vsock.socket
 
 install_client: (build "release")
 	install -Dm755 {{helper_binary}} {{destdir}}{{bridgedir}}/http
 	ln -sf http {{destdir}}{{bridgedir}}/https
 	ln -sf http {{destdir}}{{bridgedir}}/ws
 	ln -sf http {{destdir}}{{bridgedir}}/wss
+	ln -sf http {{destdir}}{{bridgedir}}/vsock
 
 install_config:
 	install -dm755 {{destdir}}{{sysconfdir}}/varlink-httpd

--- a/justfile
+++ b/justfile
@@ -20,6 +20,7 @@ install_client: (build "release")
 	ln -sf http {{destdir}}{{bridgedir}}/ws
 	ln -sf http {{destdir}}{{bridgedir}}/wss
 	ln -sf http {{destdir}}{{bridgedir}}/vsock
+	ln -sf http {{destdir}}{{bridgedir}}/vsock+tls
 
 install_config:
 	install -dm755 {{destdir}}{{sysconfdir}}/varlink-httpd

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -20,7 +20,7 @@ use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::fs::FileTypeExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -967,9 +967,7 @@ fn listener_from_activated_fd(
     let addr = rustix::net::getsockname(fd.as_fd())?;
     match addr.address_family() {
         rustix::net::AddressFamily::VSOCK => {
-            // TODO: use VsockListener::from(fd) once tokio-vsock has From<OwnedFd>
-            // c.f. https://github.com/rust-vsock/tokio-vsock/pull/72
-            let listener = unsafe { VsockListener::from_raw_fd(fd.into_raw_fd()) };
+            let listener = VsockListener::from(fd);
             Ok((Transport::Vsock(listener), tls_acceptor))
         }
         rustix::net::AddressFamily::INET | rustix::net::AddressFamily::INET6 => {

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -462,6 +462,16 @@ impl Connected<IncomingStream<'_, VsockListener>> for VarlinkConnCache {
     }
 }
 
+impl Connected<IncomingStream<'_, AsyncTlsListener<VsockListener>>> for VarlinkConnCache {
+    fn connect_info(target: IncomingStream<'_, AsyncTlsListener<VsockListener>>) -> Self {
+        let ssl = target.io().ssl();
+        let peer = target.remote_addr();
+        info!("New TLS vsock connection from CID {}", peer.cid());
+        let tls_channel_binding = varlink_http_bridge::export_tls_channel_binding(ssl);
+        Self::new(Some(tls_channel_binding))
+    }
+}
+
 fn load_tls_acceptor(
     cert_path: &str,
     key_path: &str,
@@ -957,13 +967,10 @@ fn listener_from_activated_fd(
     let addr = rustix::net::getsockname(fd.as_fd())?;
     match addr.address_family() {
         rustix::net::AddressFamily::VSOCK => {
-            if tls_acceptor.is_some() {
-                bail!("TLS over vsock is not yet supported");
-            }
             // TODO: use VsockListener::from(fd) once tokio-vsock has From<OwnedFd>
             // c.f. https://github.com/rust-vsock/tokio-vsock/pull/72
             let listener = unsafe { VsockListener::from_raw_fd(fd.into_raw_fd()) };
-            Ok((Transport::Vsock(listener), None))
+            Ok((Transport::Vsock(listener), tls_acceptor))
         }
         rustix::net::AddressFamily::INET | rustix::net::AddressFamily::INET6 => {
             let std_listener = std::net::TcpListener::from(fd);
@@ -979,15 +986,9 @@ fn listener_from_activated_fd(
 }
 
 /// Create a [`Transport`] from an explicit `--bind` address.
-async fn listener_from_bind_addr(
-    bind: BindAddr,
-    tls_acceptor: Option<&openssl::ssl::SslAcceptor>,
-) -> anyhow::Result<Transport> {
+async fn listener_from_bind_addr(bind: BindAddr) -> anyhow::Result<Transport> {
     match bind {
         BindAddr::Vsock { cid, port } => {
-            if tls_acceptor.is_some() {
-                bail!("TLS over vsock is not yet supported");
-            }
             let listener = VsockListener::bind(tokio_vsock::VsockAddr::new(cid, port))
                 .with_context(|| format!("vsock bind to CID {cid}, port {port}"))?;
             Ok(Transport::Vsock(listener))
@@ -1007,8 +1008,10 @@ async fn serve_listener(
     let make_svc = app.into_make_service_with_connect_info::<VarlinkConnCache>();
 
     match (listener, tls_acceptor) {
-        (Transport::Vsock(_), Some(_)) => {
-            bail!("TLS over vsock is not yet supported");
+        (Transport::Vsock(l), Some(acceptor)) => {
+            axum::serve(AsyncTlsListener::new(l, acceptor)?, make_svc)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
         }
         (Transport::Vsock(l), None) => {
             axum::serve(l, make_svc)

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -999,20 +999,11 @@ async fn listener_from_bind_addr(
     }
 }
 
-async fn start_server(
+async fn serve_listener(
     listener: Transport,
     tls_acceptor: Option<openssl::ssl::SslAcceptor>,
-    varlink_sockets_path: &str,
-    authenticators: Vec<Box<dyn Authenticator>>,
+    app: Router,
 ) -> anyhow::Result<()> {
-    let scheme = if tls_acceptor.is_some() {
-        "HTTPS"
-    } else {
-        "HTTP"
-    };
-    eprintln!("Forwarding {scheme} {listener} -> Varlink: {varlink_sockets_path}");
-
-    let app = create_router(varlink_sockets_path, authenticators)?;
     let make_svc = app.into_make_service_with_connect_info::<VarlinkConnCache>();
 
     match (listener, tls_acceptor) {
@@ -1038,6 +1029,17 @@ async fn start_server(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+async fn start_server(
+    listener: Transport,
+    tls_acceptor: Option<openssl::ssl::SslAcceptor>,
+    varlink_sockets_path: &str,
+    authenticators: Vec<Box<dyn Authenticator>>,
+) -> anyhow::Result<()> {
+    let app = create_router(varlink_sockets_path, authenticators)?;
+    serve_listener(listener, tls_acceptor, app).await
 }
 
 #[derive(Debug)]
@@ -1124,7 +1126,7 @@ impl std::str::FromStr for BindAddr {
 
 #[derive(Debug)]
 struct BridgeCli {
-    bind: BindAddr,
+    binds: Vec<BindAddr>,
     varlink_sockets_path: String,
     cert: Option<String>,
     key: Option<String>,
@@ -1149,7 +1151,8 @@ fn print_help() {
         Bridge options:
           VARLINK_SOCKETS_PATH              directory of sockets or a single socket
                                             (default: /run/varlink/registry)
-          --bind=ADDR                       address to bind to (default: 0.0.0.0:{DEFAULT_PORT})
+          --bind=ADDR                       address to bind to (repeatable;
+                                            default: 0.0.0.0:{DEFAULT_PORT})
                                             use vsock::PORT for vsock (e.g. vsock::{DEFAULT_PORT})
           --cert=PATH                       TLS certificate PEM file
           --key=PATH                        TLS private key PEM file
@@ -1180,7 +1183,7 @@ fn print_import_ssh_help() {
 fn parse_cli() -> anyhow::Result<Command> {
     use lexopt::prelude::*;
 
-    let mut bind_str = format!("0.0.0.0:{DEFAULT_PORT}");
+    let mut bind_strs: Vec<String> = Vec::new();
     let mut varlink_sockets_path = String::from("/run/varlink/registry");
     let mut cert = None;
     let mut key = None;
@@ -1192,7 +1195,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
         match arg {
-            Long("bind") => bind_str = parser.value()?.parse()?,
+            Long("bind") => bind_strs.push(parser.value()?.parse()?),
             Long("cert") => cert = Some(parser.value()?.parse()?),
             Long("key") => key = Some(parser.value()?.parse()?),
             Long("trust") => trust = Some(parser.value()?.parse()?),
@@ -1218,10 +1221,16 @@ fn parse_cli() -> anyhow::Result<Command> {
         }
     }
 
-    let bind: BindAddr = bind_str.parse()?;
+    if bind_strs.is_empty() {
+        bind_strs.push(format!("0.0.0.0:{DEFAULT_PORT}"));
+    }
+    let binds: Vec<BindAddr> = bind_strs
+        .iter()
+        .map(|s| s.parse())
+        .collect::<Result<_, _>>()?;
 
     Ok(Command::Bridge(BridgeCli {
-        bind,
+        binds,
         varlink_sockets_path,
         cert,
         key,
@@ -1299,35 +1308,52 @@ async fn main() -> anyhow::Result<()> {
         bail!("no authentication configured: use --authorized-keys=, --trust=, or --insecure");
     }
 
-    // Socket activation: detect fd type (TCP vs vsock) or fall back to explicit --bind
-    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"
-    let mut listenfd = ListenFd::from_env();
+    let app = create_router(&cli.varlink_sockets_path, authenticators)?;
 
-    // Check for socket-activated fd first
-    if let Some(raw_fd) = listenfd.take_raw_fd(0)? {
-        // SAFETY: listenfd.take_raw_fd() returns a valid, owned fd from socket activation
-        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
-        let (listener, tls_acceptor) = listener_from_activated_fd(fd, tls_acceptor)?;
-        eprintln!("Varlink proxy started (socket-activated)");
-        return start_server(
-            listener,
-            tls_acceptor,
-            &cli.varlink_sockets_path,
-            authenticators,
-        )
-        .await;
+    let scheme = if tls_acceptor.is_some() {
+        "HTTPS"
+    } else {
+        "HTTP"
+    };
+
+    // Socket activation: consume all activated fds, or fall back to explicit --bind
+    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"
+    let mut listeners: Vec<(Transport, Option<openssl::ssl::SslAcceptor>)> = Vec::new();
+    let mut listenfd = ListenFd::from_env();
+    for idx in 0..listenfd.len() {
+        if let Some(raw_fd) = listenfd.take_raw_fd(idx)? {
+            // SAFETY: listenfd.take_raw_fd() returns a valid, owned fd from socket activation
+            let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+            listeners.push(listener_from_activated_fd(fd, tls_acceptor.clone())?);
+        }
     }
 
-    // No socket activation: bind explicitly based on --bind (or default)
-    let listener = listener_from_bind_addr(cli.bind).await?;
-    eprintln!("Varlink proxy started");
-    start_server(
-        listener,
-        tls_acceptor,
-        &cli.varlink_sockets_path,
-        authenticators,
-    )
-    .await
+    if listeners.is_empty() {
+        // No socket activation: bind explicitly based on --bind (or default)
+        for bind in cli.binds {
+            let listener = listener_from_bind_addr(bind).await?;
+            listeners.push((listener, tls_acceptor.clone()));
+        }
+    } else {
+        eprintln!("Varlink proxy started (socket-activated)");
+    }
+
+    let mut join_set = tokio::task::JoinSet::new();
+    for (listener, tls) in listeners {
+        eprintln!(
+            "Forwarding {scheme} {listener} -> Varlink: {}",
+            cli.varlink_sockets_path
+        );
+        let app_clone = app.clone();
+        join_set.spawn(async move { serve_listener(listener, tls, app_clone).await });
+    }
+
+    // Wait for all listeners; propagate the first error
+    while let Some(result) = join_set.join_next().await {
+        result??;
+    }
+
+    Ok(())
 }
 #[cfg(test)]
 mod tests;

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -20,13 +20,14 @@ use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
-use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::os::unix::fs::FileTypeExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixStream};
 use tokio::signal;
+use tokio_vsock::VsockListener;
 use zlink::varlink_service::Proxy;
 
 #[cfg(feature = "sshauth")]
@@ -450,6 +451,14 @@ impl Connected<IncomingStream<'_, AsyncTlsListener<PlainListener>>> for VarlinkC
         log_tls_connection(ssl, target.remote_addr());
         let tls_channel_binding = varlink_http_bridge::export_tls_channel_binding(ssl);
         Self::new(Some(tls_channel_binding))
+    }
+}
+
+impl Connected<IncomingStream<'_, VsockListener>> for VarlinkConnCache {
+    fn connect_info(target: IncomingStream<'_, VsockListener>) -> Self {
+        let peer = target.remote_addr();
+        info!("New vsock connection from CID {}", peer.cid());
+        Self::new(None)
     }
 }
 
@@ -920,25 +929,112 @@ async fn shutdown_signal() {
     println!("Shutdown signal received, stopping server...");
 }
 
-async fn run_server(
-    varlink_sockets_path: &str,
-    listener: TcpListener,
+enum Transport {
+    Tcp(TcpListener),
+    Vsock(VsockListener),
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Transport::Tcp(l) => {
+                let addr = l.local_addr().map_err(|_| std::fmt::Error)?;
+                write!(f, "{addr}")
+            }
+            Transport::Vsock(l) => {
+                let addr = l.local_addr().map_err(|_| std::fmt::Error)?;
+                write!(f, "vsock:{}:{}", addr.cid(), addr.port())
+            }
+        }
+    }
+}
+
+/// Create a [`Transport`] from a socket-activated file descriptor.
+fn listener_from_activated_fd(
+    fd: OwnedFd,
     tls_acceptor: Option<openssl::ssl::SslAcceptor>,
+) -> anyhow::Result<(Transport, Option<openssl::ssl::SslAcceptor>)> {
+    let addr = rustix::net::getsockname(fd.as_fd())?;
+    match addr.address_family() {
+        rustix::net::AddressFamily::VSOCK => {
+            if tls_acceptor.is_some() {
+                bail!("TLS over vsock is not yet supported");
+            }
+            // TODO: use VsockListener::from(fd) once tokio-vsock has From<OwnedFd>
+            // c.f. https://github.com/rust-vsock/tokio-vsock/pull/72
+            let listener = unsafe { VsockListener::from_raw_fd(fd.into_raw_fd()) };
+            Ok((Transport::Vsock(listener), None))
+        }
+        rustix::net::AddressFamily::INET | rustix::net::AddressFamily::INET6 => {
+            let std_listener = std::net::TcpListener::from(fd);
+            // needed or tokio panics, see https://github.com/mitsuhiko/listenfd/pull/23
+            std_listener.set_nonblocking(true)?;
+            Ok((
+                Transport::Tcp(TcpListener::from_std(std_listener)?),
+                tls_acceptor,
+            ))
+        }
+        family => bail!("unsupported socket family from socket activation: {family:?}"),
+    }
+}
+
+/// Create a [`Transport`] from an explicit `--bind` address.
+async fn listener_from_bind_addr(
+    bind: BindAddr,
+    tls_acceptor: Option<&openssl::ssl::SslAcceptor>,
+) -> anyhow::Result<Transport> {
+    match bind {
+        BindAddr::Vsock { cid, port } => {
+            if tls_acceptor.is_some() {
+                bail!("TLS over vsock is not yet supported");
+            }
+            let listener = VsockListener::bind(tokio_vsock::VsockAddr::new(cid, port))
+                .with_context(|| format!("vsock bind to CID {cid}, port {port}"))?;
+            Ok(Transport::Vsock(listener))
+        }
+        BindAddr::Tcp(ref addr) => {
+            let listener = TcpListener::bind(addr).await?;
+            Ok(Transport::Tcp(listener))
+        }
+    }
+}
+
+async fn start_server(
+    listener: Transport,
+    tls_acceptor: Option<openssl::ssl::SslAcceptor>,
+    varlink_sockets_path: &str,
     authenticators: Vec<Box<dyn Authenticator>>,
 ) -> anyhow::Result<()> {
+    let scheme = if tls_acceptor.is_some() {
+        "HTTPS"
+    } else {
+        "HTTP"
+    };
+    eprintln!("Forwarding {scheme} {listener} -> Varlink: {varlink_sockets_path}");
+
     let app = create_router(varlink_sockets_path, authenticators)?;
     let make_svc = app.into_make_service_with_connect_info::<VarlinkConnCache>();
 
-    if let Some(acceptor) = tls_acceptor {
-        let plain = PlainListener { inner: listener };
-        axum::serve(AsyncTlsListener::new(plain, acceptor)?, make_svc)
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
-    } else {
-        let plain_listener = PlainListener { inner: listener };
-        axum::serve(plain_listener, make_svc)
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
+    match (listener, tls_acceptor) {
+        (Transport::Vsock(_), Some(_)) => {
+            bail!("TLS over vsock is not yet supported");
+        }
+        (Transport::Vsock(l), None) => {
+            axum::serve(l, make_svc)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
+        }
+        (Transport::Tcp(l), Some(acceptor)) => {
+            let plain = PlainListener { inner: l };
+            axum::serve(AsyncTlsListener::new(plain, acceptor)?, make_svc)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
+        }
+        (Transport::Tcp(l), None) => {
+            axum::serve(PlainListener { inner: l }, make_svc)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
+        }
     }
 
     Ok(())
@@ -951,9 +1047,84 @@ enum Command {
     ImportSsh(import_ssh::ImportSsh),
 }
 
+use varlink_http_bridge::DEFAULT_PORT;
+
+#[derive(Debug)]
+enum BindAddr {
+    Tcp(String),
+    Vsock { cid: u32, port: u32 },
+}
+
+/// Parse a bind address string.
+///
+/// Strings starting with `vsock` are parsed as vsock addresses
+/// (matching systemd's `ListenStream=` syntax):
+/// - `vsock`          -> `CID_ANY`, default port
+/// - `vsock:`         -> `CID_ANY`, default port
+/// - `vsock::PORT`    -> `CID_ANY`, explicit port
+/// - `vsock:CID:PORT` -> explicit CID and port
+///
+/// Everything else is treated as a TCP address.
+impl std::str::FromStr for BindAddr {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let Some(rest) = s.strip_prefix("vsock") else {
+            return Ok(BindAddr::Tcp(s.to_string()));
+        };
+        // "vsock" or "vsock:" with nothing after
+        if rest.is_empty() || rest == ":" {
+            return Ok(BindAddr::Vsock {
+                cid: vsock::VMADDR_CID_ANY,
+                port: DEFAULT_PORT,
+            });
+        }
+        // must start with ':'
+        let rest = rest
+            .strip_prefix(':')
+            .ok_or_else(|| anyhow::anyhow!("invalid vsock bind address: {s}"))?;
+        let parts: Vec<&str> = rest.splitn(2, ':').collect();
+        match parts.as_slice() {
+            // "vsock::PORT"
+            ["", port] => Ok(BindAddr::Vsock {
+                cid: vsock::VMADDR_CID_ANY,
+                port: port
+                    .parse()
+                    .with_context(|| format!("invalid vsock port: {port}"))?,
+            }),
+            // "vsock:CID:PORT"
+            [cid, port] => Ok(BindAddr::Vsock {
+                cid: cid
+                    .parse()
+                    .with_context(|| format!("invalid vsock CID: {cid}"))?,
+                port: port
+                    .parse()
+                    .with_context(|| format!("invalid vsock port: {port}"))?,
+            }),
+            // "vsock:PORT" (single number = port, CID_ANY)
+            [port_or_empty] => {
+                if port_or_empty.is_empty() {
+                    Ok(BindAddr::Vsock {
+                        cid: vsock::VMADDR_CID_ANY,
+                        port: DEFAULT_PORT,
+                    })
+                } else {
+                    Ok(BindAddr::Vsock {
+                        cid: vsock::VMADDR_CID_ANY,
+                        port: port_or_empty
+                            .parse()
+                            .with_context(|| format!("invalid vsock port: {port_or_empty}"))?,
+                    })
+                }
+            }
+            _ => bail!("invalid vsock bind address: {s}"),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct BridgeCli {
-    bind: String,
+    bind: BindAddr,
     varlink_sockets_path: String,
     cert: Option<String>,
     key: Option<String>,
@@ -963,7 +1134,9 @@ struct BridgeCli {
 }
 
 fn print_help() {
-    eprint!(indoc::indoc! {"
+    eprint!(
+        "{}",
+        indoc::formatdoc! {"
         Usage: varlink-httpd [bridge] [OPTIONS] [VARLINK_SOCKETS_PATH]
                varlink-httpd import-ssh SOURCE [OUTPUT]
 
@@ -976,14 +1149,16 @@ fn print_help() {
         Bridge options:
           VARLINK_SOCKETS_PATH              directory of sockets or a single socket
                                             (default: /run/varlink/registry)
-          --bind=ADDR                       address to bind to (default: 0.0.0.0:1031)
+          --bind=ADDR                       address to bind to (default: 0.0.0.0:{DEFAULT_PORT})
+                                            use vsock::PORT for vsock (e.g. vsock::{DEFAULT_PORT})
           --cert=PATH                       TLS certificate PEM file
           --key=PATH                        TLS private key PEM file
           --trust=PATH                      CA certificate PEM for client verification (mTLS)
           --authorized-keys=PATH            authorized SSH public keys file
           --insecure                        run without any authentication (DANGEROUS)
           --help                            display this help and exit
-    "});
+    "}
+    );
 }
 
 #[cfg(feature = "sshauth")]
@@ -1005,7 +1180,7 @@ fn print_import_ssh_help() {
 fn parse_cli() -> anyhow::Result<Command> {
     use lexopt::prelude::*;
 
-    let mut bind = String::from("0.0.0.0:1031");
+    let mut bind_str = format!("0.0.0.0:{DEFAULT_PORT}");
     let mut varlink_sockets_path = String::from("/run/varlink/registry");
     let mut cert = None;
     let mut key = None;
@@ -1017,7 +1192,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
         match arg {
-            Long("bind") => bind = parser.value()?.parse()?,
+            Long("bind") => bind_str = parser.value()?.parse()?,
             Long("cert") => cert = Some(parser.value()?.parse()?),
             Long("key") => key = Some(parser.value()?.parse()?),
             Long("trust") => trust = Some(parser.value()?.parse()?),
@@ -1042,6 +1217,8 @@ fn parse_cli() -> anyhow::Result<Command> {
             _ => return Err(arg.unexpected().into()),
         }
     }
+
+    let bind: BindAddr = bind_str.parse()?;
 
     Ok(Command::Bridge(BridgeCli {
         bind,
@@ -1091,16 +1268,6 @@ async fn main() -> anyhow::Result<()> {
         Command::Bridge(cli) => cli,
     };
 
-    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"
-    let mut listenfd = ListenFd::from_env();
-    let listener = if let Some(std_listener) = listenfd.take_tcp_listener(0)? {
-        // needed or tokio panics, see https://github.com/mitsuhiko/listenfd/pull/23
-        std_listener.set_nonblocking(true)?;
-        TcpListener::from_std(std_listener)?
-    } else {
-        TcpListener::bind(&cli.bind).await?
-    };
-
     let creds_dir = std::env::var_os("CREDENTIALS_DIRECTORY").map(std::path::PathBuf::from);
 
     // Resolve mTLS: remember if trust was provided before consuming the options
@@ -1132,26 +1299,35 @@ async fn main() -> anyhow::Result<()> {
         bail!("no authentication configured: use --authorized-keys=, --trust=, or --insecure");
     }
 
-    let local_addr = listener.local_addr()?;
-    let scheme = if tls_acceptor.is_some() {
-        "HTTPS"
-    } else {
-        "HTTP"
-    };
+    // Socket activation: detect fd type (TCP vs vsock) or fall back to explicit --bind
+    // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"
+    let mut listenfd = ListenFd::from_env();
 
+    // Check for socket-activated fd first
+    if let Some(raw_fd) = listenfd.take_raw_fd(0)? {
+        // SAFETY: listenfd.take_raw_fd() returns a valid, owned fd from socket activation
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let (listener, tls_acceptor) = listener_from_activated_fd(fd, tls_acceptor)?;
+        eprintln!("Varlink proxy started (socket-activated)");
+        return start_server(
+            listener,
+            tls_acceptor,
+            &cli.varlink_sockets_path,
+            authenticators,
+        )
+        .await;
+    }
+
+    // No socket activation: bind explicitly based on --bind (or default)
+    let listener = listener_from_bind_addr(cli.bind).await?;
     eprintln!("Varlink proxy started");
-    eprintln!(
-        "Forwarding {scheme} {local_addr} -> Varlink: {varlink_sockets_path}",
-        varlink_sockets_path = &cli.varlink_sockets_path
-    );
-    run_server(
-        &cli.varlink_sockets_path,
+    start_server(
         listener,
         tls_acceptor,
+        &cli.varlink_sockets_path,
         authenticators,
     )
     .await
 }
-
 #[cfg(test)]
 mod tests;

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -4,10 +4,23 @@ use super::*;
 use futures_util::{SinkExt, StreamExt};
 use gethostname::gethostname;
 use reqwest::Client;
-use scopeguard::defer;
 use std::os::fd::OwnedFd;
 use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+/// Bundles a spawned test server task with its bound address.
+/// Dropping aborts the task, so each test's server is cleaned up
+/// at end of scope.
+struct TestServer<A> {
+    handle: tokio::task::JoinHandle<()>,
+    addr: A,
+}
+
+impl<A> Drop for TestServer<A> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
 
 /// A simple log capture for tests.  Installed once (via `init_test_logger`)
 /// and accumulates all `info!` and above messages so tests can assert on them.
@@ -62,25 +75,23 @@ fn helper_binary() -> std::path::PathBuf {
     helper
 }
 
-async fn run_test_server(
-    varlink_sockets_path: &str,
-) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+async fn run_test_server(varlink_sockets_path: &str) -> TestServer<std::net::SocketAddr> {
     run_test_server_with_auth(varlink_sockets_path, Vec::new()).await
 }
 
 async fn run_test_server_with_auth(
     varlink_sockets_path: &str,
     authenticators: Vec<Box<dyn Authenticator>>,
-) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+) -> TestServer<std::net::SocketAddr> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind to random port failed");
-    let local_addr = listener
+    let addr = listener
         .local_addr()
         .expect("failed to extract local address");
 
     let varlink_sockets_path = varlink_sockets_path.to_string();
-    let task_handle = tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         start_server(
             Transport::Tcp(listener),
             None,
@@ -91,22 +102,18 @@ async fn run_test_server_with_auth(
         .expect("server failed")
     });
 
-    (task_handle, local_addr)
+    TestServer { handle, addr }
 }
 
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_hostname_post() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/io.systemd.Hostname.Describe",
-            local_addr,
+            server.addr,
         ))
         .json(&json!({}))
         .send()
@@ -120,14 +127,13 @@ async fn test_integration_real_systemd_hostname_post() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
-        .get(format!("http://{}/sockets/io.systemd.Hostname", local_addr,))
+        .get(format!(
+            "http://{}/sockets/io.systemd.Hostname",
+            server.addr,
+        ))
         .send()
         .await
         .expect("failed to get from test server");
@@ -139,14 +145,10 @@ async fn test_integration_real_systemd_socket_get() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_sockets_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
-        .get(format!("http://{}/sockets", local_addr,))
+        .get(format!("http://{}/sockets", server.addr,))
         .send()
         .await
         .expect("failed to get from test server");
@@ -163,16 +165,12 @@ async fn test_integration_real_systemd_sockets_get() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_interface_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
         .get(format!(
             "http://{}/sockets/io.systemd.Hostname/io.systemd.Hostname",
-            local_addr,
+            server.addr,
         ))
         .send()
         .await
@@ -185,12 +183,8 @@ async fn test_integration_real_systemd_socket_interface_get() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_hostname_parallel() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
-    let url = format!("http://{}/call/io.systemd.Hostname.Describe", local_addr);
+    let server = run_test_server("/run/systemd").await;
+    let url = format!("http://{}/call/io.systemd.Hostname.Describe", server.addr);
 
     const NUM_TASKS: u32 = 10;
     let mut set = JoinSet::new();
@@ -227,16 +221,12 @@ async fn test_integration_real_systemd_hostname_parallel() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_query_param() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/org.varlink.service.GetInfo?socket=io.systemd.Hostname",
-            local_addr,
+            server.addr,
         ))
         .json(&json!({}))
         .send()
@@ -250,16 +240,13 @@ async fn test_integration_real_systemd_socket_query_param() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_error_bad_request_on_malformed_json() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
         .post(format!(
             "http://{}/call/org.varlink.service.GetInfo",
-            local_addr,
+            server.addr,
         ))
         .body("this is NOT valid json")
         .header("Content-Type", "application/json")
@@ -273,16 +260,13 @@ async fn test_error_bad_request_on_malformed_json() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_error_unknown_varlink_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
         .post(format!(
             "http://{}/call/no.such.address.SomeMethod",
-            local_addr,
+            server.addr,
         ))
         .body("{}")
         .header("Content-Type", "application/json")
@@ -302,16 +286,13 @@ async fn test_error_unknown_varlink_address() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_error_404_for_missing_method() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
         .post(format!(
             "http://{}/call/com.missing.Call?socket=io.systemd.Hostname",
-            local_addr
+            server.addr
         ))
         .json(&json!({}))
         .send()
@@ -326,17 +307,14 @@ async fn test_error_404_for_missing_method() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_error_bad_request_for_unclean_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
         .post(format!(
             // %2f is url encoding for "/" so socket param is ../io.systemd.Hostname
             "http://{}/call/com.missing.Call?socket=..%2fio.systemd.Hostname",
-            local_addr
+            server.addr
         ))
         .json(&json!({}))
         .send()
@@ -354,17 +332,14 @@ async fn test_error_bad_request_for_unclean_address() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_error_bad_request_for_invalid_chars_in_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
         .post(format!(
             // %0A is \n
             "http://{}/call/com.missing.Call?socket=io.systemd.Hostname%0Abad-msg",
-            local_addr
+            server.addr
         ))
         .json(&json!({}))
         .send()
@@ -382,14 +357,11 @@ async fn test_error_bad_request_for_invalid_chars_in_address() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_error_bad_request_for_method_without_dots() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
 
     let res = client
-        .post(format!("http://{}/call/NoDots", local_addr))
+        .post(format!("http://{}/call/NoDots", server.addr))
         .json(&json!({}))
         .send()
         .await
@@ -406,14 +378,10 @@ async fn test_error_bad_request_for_method_without_dots() {
 #[test_with::path(/run/systemd)]
 #[tokio::test]
 async fn test_health_endpoint() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
-        .get(format!("http://{}/health", local_addr))
+        .get(format!("http://{}/health", server.addr))
         .send()
         .await
         .expect("failed to get health endpoint");
@@ -447,16 +415,12 @@ async fn test_varlink_sockets_dir_or_file_missing() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_single_socket_post() {
-    let (server, local_addr) = run_test_server("/run/systemd/io.systemd.Hostname").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd/io.systemd.Hostname").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/io.systemd.Hostname.Describe",
-            local_addr,
+            server.addr,
         ))
         .json(&json!({}))
         .send()
@@ -470,16 +434,12 @@ async fn test_single_socket_post() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_single_socket_rejects_wrong_name() {
-    let (server, local_addr) = run_test_server("/run/systemd/io.systemd.Hostname").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd/io.systemd.Hostname").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/io.systemd.Wrong.Describe",
-            local_addr,
+            server.addr,
         ))
         .json(&json!({}))
         .send()
@@ -532,12 +492,8 @@ async fn test_varlink_unix_sockets_in_skips_dangling_symlinks() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_ws_hostname_describe() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
-    let url = format!("ws://{local_addr}/ws/sockets/io.systemd.Hostname");
+    let server = run_test_server("/run/systemd").await;
+    let url = format!("ws://{}/ws/sockets/io.systemd.Hostname", server.addr);
     let (mut ws, _) = tokio_tungstenite::connect_async(&url)
         .await
         .expect("WS connect failed");
@@ -566,12 +522,8 @@ async fn test_ws_hostname_describe() {
 #[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
 #[tokio::test]
 async fn test_ws_userdb_get_user_record_more() {
-    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
-    defer! {
-        server.abort();
-    };
-
-    let url = format!("ws://{local_addr}/ws/sockets/io.systemd.Multiplexer");
+    let server = run_test_server("/run/systemd/userdb").await;
+    let url = format!("ws://{}/ws/sockets/io.systemd.Multiplexer", server.addr);
     let (mut ws, _) = tokio_tungstenite::connect_async(&url)
         .await
         .expect("WS connect failed");
@@ -671,16 +623,12 @@ fn parse_json_seq(body: &[u8]) -> Vec<Value> {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_jsonseq_hostname_describe() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/io.systemd.Hostname.Describe",
-            local_addr,
+            server.addr,
         ))
         .header("Accept", "application/json-seq")
         .json(&json!({}))
@@ -711,16 +659,12 @@ async fn test_jsonseq_hostname_describe() {
 #[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
 #[tokio::test]
 async fn test_jsonseq_userdb_get_user_record_more() {
-    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_server("/run/systemd/userdb").await;
     let client = Client::new();
     let res = client
         .post(format!(
             "http://{}/call/io.systemd.UserDatabase.GetUserRecord?socket=io.systemd.Multiplexer",
-            local_addr,
+            server.addr,
         ))
         .header("Accept", "application/json-seq")
         .json(&json!({"service": "io.systemd.Multiplexer"}))
@@ -755,12 +699,8 @@ async fn test_jsonseq_userdb_get_user_record_more() {
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlinkctl_helper_hostname_describe() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
-    defer! {
-        server.abort();
-    };
-
-    let bridge_url = format!("http://{local_addr}/ws/sockets/io.systemd.Hostname");
+    let server = run_test_server("/run/systemd").await;
+    let bridge_url = format!("http://{}/ws/sockets/io.systemd.Hostname", server.addr);
     let output = tokio::process::Command::new("varlinkctl")
         .args([
             "call",
@@ -793,12 +733,8 @@ async fn test_varlinkctl_helper_hostname_describe() {
 #[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
 #[tokio::test]
 async fn test_varlinkctl_helper_userdb_get_user_record() {
-    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
-    defer! {
-        server.abort();
-    };
-
-    let bridge_url = format!("http://{local_addr}/ws/sockets/io.systemd.Multiplexer");
+    let server = run_test_server("/run/systemd/userdb").await;
+    let bridge_url = format!("http://{}/ws/sockets/io.systemd.Multiplexer", server.addr);
     let output = tokio::process::Command::new("varlinkctl")
         .args([
             "call",
@@ -931,7 +867,7 @@ fn make_test_pki() -> TestPki {
 async fn run_test_tls_server(
     varlink_sockets_path: &str,
     tls_acceptor: openssl::ssl::SslAcceptor,
-) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+) -> TestServer<std::net::SocketAddr> {
     run_test_tls_server_with_auth(varlink_sockets_path, tls_acceptor, Vec::new()).await
 }
 
@@ -939,16 +875,16 @@ async fn run_test_tls_server_with_auth(
     varlink_sockets_path: &str,
     tls_acceptor: openssl::ssl::SslAcceptor,
     authenticators: Vec<Box<dyn Authenticator>>,
-) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+) -> TestServer<std::net::SocketAddr> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind to random port failed");
-    let local_addr = listener
+    let addr = listener
         .local_addr()
         .expect("failed to extract local address");
 
     let varlink_sockets_path = varlink_sockets_path.to_string();
-    let task_handle = tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         start_server(
             Transport::Tcp(listener),
             Some(tls_acceptor),
@@ -959,7 +895,7 @@ async fn run_test_tls_server_with_auth(
         .expect("server failed")
     });
 
-    (task_handle, local_addr)
+    TestServer { handle, addr }
 }
 
 #[test_with::path(/usr/bin/openssl)]
@@ -975,21 +911,16 @@ async fn test_tls_basic_connection() {
     )
     .unwrap();
 
-    let (server, local_addr) =
-        run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
     let ca_cert = reqwest::Certificate::from_pem(&pki.ca_cert_pem).unwrap();
     let client = Client::builder()
         .add_root_certificate(ca_cert)
-        .resolve("localhost", local_addr)
+        .resolve("localhost", server.addr)
         .build()
         .unwrap();
 
     let res = client
-        .get(format!("https://localhost:{}/health", local_addr.port()))
+        .get(format!("https://localhost:{}/health", server.addr.port()))
         .send()
         .await
         .expect("TLS connection failed");
@@ -1011,22 +942,17 @@ async fn test_mtls_accepts_client_cert_and_rejects_without() {
     )
     .unwrap();
 
-    let (server, local_addr) =
-        run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
     // Without a client certificate the TLS handshake is rejected
     let ca_cert = reqwest::Certificate::from_pem(&pki.ca_cert_pem).unwrap();
     let client_no_cert = Client::builder()
         .add_root_certificate(ca_cert)
-        .resolve("localhost", local_addr)
+        .resolve("localhost", server.addr)
         .build()
         .unwrap();
 
     let result = client_no_cert
-        .get(format!("https://localhost:{}/health", local_addr.port()))
+        .get(format!("https://localhost:{}/health", server.addr.port()))
         .send()
         .await;
     assert!(
@@ -1041,12 +967,12 @@ async fn test_mtls_accepts_client_cert_and_rejects_without() {
     let client_with_cert = Client::builder()
         .add_root_certificate(ca_cert)
         .identity(identity)
-        .resolve("localhost", local_addr)
+        .resolve("localhost", server.addr)
         .build()
         .unwrap();
 
     let res = client_with_cert
-        .get(format!("https://localhost:{}/health", local_addr.port()))
+        .get(format!("https://localhost:{}/health", server.addr.port()))
         .send()
         .await
         .expect("mTLS connection with client cert failed");
@@ -1078,21 +1004,16 @@ async fn test_tls_credentials_directory_fallback() {
         .expect("expected Some(acceptor) from credentials directory");
 
     let varlink_dir = tempfile::tempdir().unwrap();
-    let (server, local_addr) =
-        run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
     let ca_cert = reqwest::Certificate::from_pem(&pki.ca_cert_pem).unwrap();
     let client = Client::builder()
         .add_root_certificate(ca_cert)
-        .resolve("localhost", local_addr)
+        .resolve("localhost", server.addr)
         .build()
         .unwrap();
 
     let res = client
-        .get(format!("https://localhost:{}/health", local_addr.port()))
+        .get(format!("https://localhost:{}/health", server.addr.port()))
         .send()
         .await
         .expect("TLS via credentials directory failed");
@@ -1113,11 +1034,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
     )
     .unwrap();
 
-    let (server, local_addr) = run_test_tls_server("/run/systemd", acceptor).await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_tls_server("/run/systemd", acceptor).await;
     let fake_xdg_home = tempfile::tempdir().unwrap();
     let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
     std::fs::create_dir_all(&tls_dir).unwrap();
@@ -1127,7 +1044,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
 
     let bridge_url = format!(
         "https://localhost:{}/ws/sockets/io.systemd.Hostname",
-        local_addr.port()
+        server.addr.port()
     );
 
     let output = tokio::process::Command::new("varlinkctl")
@@ -1173,11 +1090,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
     )
     .unwrap();
 
-    let (server, local_addr) = run_test_tls_server("/run/systemd", acceptor).await;
-    defer! {
-        server.abort();
-    };
-
+    let server = run_test_tls_server("/run/systemd", acceptor).await;
     // Provide the server CA (so the client trusts the server) but NO client cert/key
     let fake_xdg_home = tempfile::tempdir().unwrap();
     let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
@@ -1186,7 +1099,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
 
     let bridge_url = format!(
         "https://localhost:{}/ws/sockets/io.systemd.Hostname",
-        local_addr.port()
+        server.addr.port()
     );
 
     let output = tokio::process::Command::new("varlinkctl")
@@ -1355,14 +1268,14 @@ fn vsock_loopback_available() -> bool {
     ok
 }
 
-async fn run_test_vsock_server(varlink_sockets_path: &str) -> (ServerHandle, u32) {
+async fn run_test_vsock_server(varlink_sockets_path: &str) -> TestServer<u32> {
     // Use port 0 to get an ephemeral port
     let listener = VsockListener::bind(tokio_vsock::VsockAddr::new(vsock::VMADDR_CID_ANY, 0))
         .expect("vsock bind failed");
-    let port = listener.local_addr().expect("local_addr failed").port();
+    let addr = listener.local_addr().expect("local_addr failed").port();
 
     let varlink_sockets_path = varlink_sockets_path.to_string();
-    let task_handle = tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         start_server(
             Transport::Vsock(listener),
             None,
@@ -1373,7 +1286,7 @@ async fn run_test_vsock_server(varlink_sockets_path: &str) -> (ServerHandle, u32
         .expect("vsock server failed")
     });
 
-    (ServerHandle(task_handle), port)
+    TestServer { handle, addr }
 }
 
 #[test_with::path(/run/systemd/io.systemd.Hostname)]
@@ -1384,9 +1297,9 @@ async fn test_vsock_health_endpoint() {
         return;
     }
 
-    let (_server, port) = run_test_vsock_server("/run/systemd").await;
+    let server = run_test_vsock_server("/run/systemd").await;
     // Connect over vsock loopback (CID 1) and do a raw HTTP GET /health
-    let mut stream = tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(1, port))
+    let mut stream = tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(1, server.addr))
         .await
         .expect("vsock connect failed");
 
@@ -1413,8 +1326,8 @@ async fn test_varlinkctl_helper_vsock_hostname_describe() {
         return;
     }
 
-    let (_server, port) = run_test_vsock_server("/run/systemd").await;
-    let bridge_url = format!("vsock://1:{port}/ws/sockets/io.systemd.Hostname");
+    let server = run_test_vsock_server("/run/systemd").await;
+    let bridge_url = format!("vsock://1:{}/ws/sockets/io.systemd.Hostname", server.addr);
     let output = tokio::process::Command::new("varlinkctl")
         .args([
             "call",
@@ -1963,12 +1876,8 @@ mod sshauth_tests {
         )
         .unwrap();
 
-        let (server, local_addr) =
+        let server =
             run_test_tls_server_with_auth("/run/systemd", acceptor, vec![Box::new(auth)]).await;
-        defer! {
-            server.abort();
-        };
-
         let fake_xdg_home = tempfile::tempdir().unwrap();
         let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
         std::fs::create_dir_all(&tls_dir).unwrap();
@@ -1976,7 +1885,7 @@ mod sshauth_tests {
 
         let bridge_url = format!(
             "https://localhost:{}/ws/sockets/io.systemd.Hostname",
-            local_addr.port()
+            server.addr.port()
         );
 
         let output = tokio::process::Command::new("varlinkctl")

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -81,9 +81,14 @@ async fn run_test_server_with_auth(
 
     let varlink_sockets_path = varlink_sockets_path.to_string();
     let task_handle = tokio::spawn(async move {
-        run_server(&varlink_sockets_path, listener, None, authenticators)
-            .await
-            .expect("server failed")
+        start_server(
+            Transport::Tcp(listener),
+            None,
+            &varlink_sockets_path,
+            authenticators,
+        )
+        .await
+        .expect("server failed")
     });
 
     (task_handle, local_addr)
@@ -423,7 +428,13 @@ async fn test_varlink_sockets_dir_or_file_missing() {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind to random port failed");
-    let res = run_server(&varlink_sockets_dir_or_file, listener, None, Vec::new()).await;
+    let res = start_server(
+        Transport::Tcp(listener),
+        None,
+        &varlink_sockets_dir_or_file,
+        Vec::new(),
+    )
+    .await;
 
     assert!(res.is_err());
     assert!(
@@ -938,10 +949,10 @@ async fn run_test_tls_server_with_auth(
 
     let varlink_sockets_path = varlink_sockets_path.to_string();
     let task_handle = tokio::spawn(async move {
-        run_server(
-            &varlink_sockets_path,
-            listener,
+        start_server(
+            Transport::Tcp(listener),
             Some(tls_acceptor),
+            &varlink_sockets_path,
             authenticators,
         )
         .await
@@ -1247,6 +1258,187 @@ fn test_format_x509_subject_multiple_fields() {
     let cert = openssl::x509::X509::from_pem(&pem).unwrap();
     let subject = format_x509_subject(&cert);
     assert_eq!(subject, "O=TestOrg, CN=multi-field");
+}
+
+// --- bind address parsing tests ---
+
+#[test]
+fn test_bind_addr_parse_defaults() {
+    // "vsock" and "vsock:" both mean CID_ANY + default port
+    for input in ["vsock", "vsock:"] {
+        let bind: BindAddr = input.parse().unwrap();
+        match bind {
+            BindAddr::Vsock { cid, port } => {
+                assert_eq!(cid, vsock::VMADDR_CID_ANY, "input: {input}");
+                assert_eq!(port, DEFAULT_PORT, "input: {input}");
+            }
+            _ => panic!("expected Vsock, got {bind:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_bind_addr_parse_port_only() {
+    // "vsock::2000" -> CID_ANY, port 2000
+    let bind: BindAddr = "vsock::2000".parse().unwrap();
+    match bind {
+        BindAddr::Vsock { cid, port } => {
+            assert_eq!(cid, vsock::VMADDR_CID_ANY);
+            assert_eq!(port, 2000);
+        }
+        _ => panic!("expected Vsock"),
+    }
+}
+
+#[test]
+fn test_bind_addr_parse_cid_and_port() {
+    // "vsock:5:3333" -> CID 5, port 3333
+    let bind: BindAddr = "vsock:5:3333".parse().unwrap();
+    match bind {
+        BindAddr::Vsock { cid, port } => {
+            assert_eq!(cid, 5);
+            assert_eq!(port, 3333);
+        }
+        _ => panic!("expected Vsock"),
+    }
+}
+
+#[test]
+fn test_bind_addr_parse_tcp() {
+    let bind: BindAddr = "0.0.0.0:1031".parse().unwrap();
+    match bind {
+        BindAddr::Tcp(addr) => assert_eq!(addr, "0.0.0.0:1031"),
+        _ => panic!("expected Tcp"),
+    }
+}
+
+#[test]
+fn test_bind_addr_parse_errors() {
+    assert!("vsock::notaport".parse::<BindAddr>().is_err());
+    assert!("vsock:abc:1031".parse::<BindAddr>().is_err());
+}
+
+// --- vsock integration tests ---
+
+/// Check if vsock loopback (CID 1) is functional.
+/// Returns false if the vsock_loopback module is not loaded.
+fn vsock_loopback_available() -> bool {
+    use std::io::Read;
+
+    let listener = match vsock::VsockListener::bind_with_cid_port(vsock::VMADDR_CID_ANY, 0) {
+        Ok(l) => l,
+        Err(_) => return false,
+    };
+    let port = match listener.local_addr() {
+        Ok(a) => a.port(),
+        Err(_) => return false,
+    };
+
+    // Spawn a thread to accept one connection so we can test connect
+    let handle = std::thread::spawn(move || {
+        listener
+            .set_nonblocking(false)
+            .expect("set_nonblocking failed");
+        match listener.accept() {
+            Ok((mut conn, _)) => {
+                let mut buf = [0u8; 1];
+                let _ = conn.read(&mut buf);
+            }
+            Err(_) => {}
+        }
+    });
+
+    let ok = vsock::VsockStream::connect_with_cid_port(1, port).is_ok();
+    // Clean up: connect success wakes the accept, connect failure means thread is stuck
+    // on accept -- drop the listener (which is moved into the thread) to unblock it
+    let _ = handle.join();
+    ok
+}
+
+async fn run_test_vsock_server(varlink_sockets_path: &str) -> (ServerHandle, u32) {
+    // Use port 0 to get an ephemeral port
+    let listener = VsockListener::bind(tokio_vsock::VsockAddr::new(vsock::VMADDR_CID_ANY, 0))
+        .expect("vsock bind failed");
+    let port = listener.local_addr().expect("local_addr failed").port();
+
+    let varlink_sockets_path = varlink_sockets_path.to_string();
+    let task_handle = tokio::spawn(async move {
+        start_server(
+            Transport::Vsock(listener),
+            None,
+            &varlink_sockets_path,
+            Vec::new(),
+        )
+        .await
+        .expect("vsock server failed")
+    });
+
+    (ServerHandle(task_handle), port)
+}
+
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_vsock_health_endpoint() {
+    if !vsock_loopback_available() {
+        eprintln!("SKIP: vsock loopback not available (vsock_loopback module not loaded?)");
+        return;
+    }
+
+    let (_server, port) = run_test_vsock_server("/run/systemd").await;
+    // Connect over vsock loopback (CID 1) and do a raw HTTP GET /health
+    let mut stream = tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(1, port))
+        .await
+        .expect("vsock connect failed");
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: vsock\r\n\r\n")
+        .await
+        .expect("write failed");
+    let mut buf = vec![0u8; 1024];
+    let n = stream.read(&mut buf).await.expect("read failed");
+    let response = String::from_utf8_lossy(&buf[..n]);
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "expected 200 OK, got: {response}"
+    );
+}
+
+#[test_with::path(/usr/bin/varlinkctl)]
+#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[tokio::test]
+async fn test_varlinkctl_helper_vsock_hostname_describe() {
+    if !vsock_loopback_available() {
+        eprintln!("SKIP: vsock loopback not available (vsock_loopback module not loaded?)");
+        return;
+    }
+
+    let (_server, port) = run_test_vsock_server("/run/systemd").await;
+    let bridge_url = format!("vsock://1:{port}/ws/sockets/io.systemd.Hostname");
+    let output = tokio::process::Command::new("varlinkctl")
+        .args([
+            "call",
+            "--json=short",
+            &format!("exec:{}", helper_binary().display()),
+            "io.systemd.Hostname.Describe",
+            "{}",
+        ])
+        .env("VARLINK_BRIDGE_URL", &bridge_url)
+        .output()
+        .await
+        .expect("failed to run varlinkctl");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "varlinkctl over vsock failed (stderr: {stderr})"
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let line = stdout.trim().trim_start_matches('\x1e');
+    let body: Value = serde_json::from_str(line).expect("invalid JSON from varlinkctl");
+    let expected_hostname = gethostname().into_string().expect("failed to get hostname");
+    assert_eq!(body["Hostname"], expected_hostname);
 }
 
 // --- SSH key auth tests ---

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -33,6 +33,7 @@ enum Stream {
     Plain(TcpStream),
     Tls(openssl::ssl::SslStream<TcpStream>),
     Vsock(vsock::VsockStream),
+    TlsVsock(openssl::ssl::SslStream<vsock::VsockStream>),
 }
 
 impl Read for Stream {
@@ -41,6 +42,7 @@ impl Read for Stream {
             Stream::Plain(s) => s.read(buf),
             Stream::Tls(s) => s.read(buf),
             Stream::Vsock(s) => s.read(buf),
+            Stream::TlsVsock(s) => s.read(buf),
         }
     }
 }
@@ -51,6 +53,7 @@ impl Write for Stream {
             Stream::Plain(s) => s.write(buf),
             Stream::Tls(s) => s.write(buf),
             Stream::Vsock(s) => s.write(buf),
+            Stream::TlsVsock(s) => s.write(buf),
         }
     }
 
@@ -59,6 +62,7 @@ impl Write for Stream {
             Stream::Plain(s) => s.flush(),
             Stream::Tls(s) => s.flush(),
             Stream::Vsock(s) => s.flush(),
+            Stream::TlsVsock(s) => s.flush(),
         }
     }
 }
@@ -69,6 +73,7 @@ impl Stream {
             Stream::Plain(s) => s.set_nonblocking(nonblocking),
             Stream::Tls(s) => s.get_ref().set_nonblocking(nonblocking),
             Stream::Vsock(s) => s.set_nonblocking(nonblocking),
+            Stream::TlsVsock(s) => s.get_ref().set_nonblocking(nonblocking),
         }
     }
 
@@ -77,6 +82,7 @@ impl Stream {
             Stream::Plain(s) => s.set_read_timeout(dur),
             Stream::Tls(s) => s.get_ref().set_read_timeout(dur),
             Stream::Vsock(s) => s.set_read_timeout(dur),
+            Stream::TlsVsock(s) => s.get_ref().set_read_timeout(dur),
         }
     }
 
@@ -85,6 +91,7 @@ impl Stream {
             Stream::Plain(s) => s.set_write_timeout(dur),
             Stream::Tls(s) => s.get_ref().set_write_timeout(dur),
             Stream::Vsock(s) => s.set_write_timeout(dur),
+            Stream::TlsVsock(s) => s.get_ref().set_write_timeout(dur),
         }
     }
 }
@@ -95,6 +102,7 @@ impl std::os::fd::AsFd for Stream {
             Stream::Plain(s) => s.as_fd(),
             Stream::Tls(s) => s.get_ref().as_fd(),
             Stream::Vsock(s) => s.as_fd(),
+            Stream::TlsVsock(s) => s.get_ref().as_fd(),
         }
     }
 }
@@ -163,12 +171,29 @@ fn parse_vsock_url(url: &str) -> Result<(u32, u32, String)> {
     Ok((cid, port, path.to_string()))
 }
 
-fn connect_vsock(url: &str) -> Result<(Stream, String, Option<String>)> {
+fn connect_vsock(url: &str, use_tls: bool) -> Result<(Stream, String, Option<String>)> {
     let (cid, port, path) = parse_vsock_url(url)?;
-    let stream = vsock::VsockStream::connect_with_cid_port(cid, port)
+    let raw_stream = vsock::VsockStream::connect_with_cid_port(cid, port)
         .with_context(|| format!("vsock connect to CID {cid}:{port} failed"))?;
-    let ws_url = format!("ws://vsock{path}");
-    Ok((Stream::Vsock(stream), ws_url, None))
+
+    if use_tls {
+        let connector = build_ssl_connector()?;
+        // vsock has no hostnames - skip hostname verification but still
+        // verify the peer certificate against the CA chain
+        let mut config = connector.configure().context("SSL configure for vsock")?;
+        config.set_verify_hostname(false);
+        let tls_stream = config.connect("vsock", raw_stream).context(
+            "TLS handshake over vsock failed: check client cert if server requires mTLS",
+        )?;
+        let tls_channel_binding = Some(varlink_http_bridge::export_tls_channel_binding(
+            tls_stream.ssl(),
+        ));
+        let ws_url = format!("wss://vsock{path}");
+        Ok((Stream::TlsVsock(tls_stream), ws_url, tls_channel_binding))
+    } else {
+        let ws_url = format!("ws://vsock{path}");
+        Ok((Stream::Vsock(raw_stream), ws_url, None))
+    }
 }
 
 fn connect_tcp(url: &str) -> Result<(Stream, String, Option<String>)> {
@@ -211,8 +236,11 @@ fn connect_tcp(url: &str) -> Result<(Stream, String, Option<String>)> {
 fn connect_ws(url: &str) -> Result<Ws> {
     use tungstenite::client::IntoClientRequest;
 
-    let (stream, ws_url, tls_channel_binding) = if url.starts_with("vsock://") {
-        connect_vsock(url)?
+    let (stream, ws_url, tls_channel_binding) = if let Some(rest) = url.strip_prefix("vsock+tls://")
+    {
+        connect_vsock(&format!("vsock://{rest}"), true)?
+    } else if url.starts_with("vsock://") {
+        connect_vsock(url, false)?
     } else {
         connect_tcp(url)?
     };

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -32,6 +32,7 @@ fn maybe_add_auth_headers(
 enum Stream {
     Plain(TcpStream),
     Tls(openssl::ssl::SslStream<TcpStream>),
+    Vsock(vsock::VsockStream),
 }
 
 impl Read for Stream {
@@ -39,6 +40,7 @@ impl Read for Stream {
         match self {
             Stream::Plain(s) => s.read(buf),
             Stream::Tls(s) => s.read(buf),
+            Stream::Vsock(s) => s.read(buf),
         }
     }
 }
@@ -48,6 +50,7 @@ impl Write for Stream {
         match self {
             Stream::Plain(s) => s.write(buf),
             Stream::Tls(s) => s.write(buf),
+            Stream::Vsock(s) => s.write(buf),
         }
     }
 
@@ -55,18 +58,48 @@ impl Write for Stream {
         match self {
             Stream::Plain(s) => s.flush(),
             Stream::Tls(s) => s.flush(),
+            Stream::Vsock(s) => s.flush(),
+        }
+    }
+}
+
+impl Stream {
+    fn set_nonblocking(&self, nonblocking: bool) -> std::io::Result<()> {
+        match self {
+            Stream::Plain(s) => s.set_nonblocking(nonblocking),
+            Stream::Tls(s) => s.get_ref().set_nonblocking(nonblocking),
+            Stream::Vsock(s) => s.set_nonblocking(nonblocking),
+        }
+    }
+
+    fn set_read_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        match self {
+            Stream::Plain(s) => s.set_read_timeout(dur),
+            Stream::Tls(s) => s.get_ref().set_read_timeout(dur),
+            Stream::Vsock(s) => s.set_read_timeout(dur),
+        }
+    }
+
+    fn set_write_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        match self {
+            Stream::Plain(s) => s.set_write_timeout(dur),
+            Stream::Tls(s) => s.get_ref().set_write_timeout(dur),
+            Stream::Vsock(s) => s.set_write_timeout(dur),
+        }
+    }
+}
+
+impl std::os::fd::AsFd for Stream {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        match self {
+            Stream::Plain(s) => s.as_fd(),
+            Stream::Tls(s) => s.get_ref().as_fd(),
+            Stream::Vsock(s) => s.as_fd(),
         }
     }
 }
 
 type Ws = WebSocket<Stream>;
-
-fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
-    match ws.get_ref() {
-        Stream::Plain(s) => s,
-        Stream::Tls(s) => s.get_ref(),
-    }
-}
 
 /// Build an `SslConnector` with client certs and a custom CA loaded from the
 /// first existing directory:
@@ -112,9 +145,33 @@ fn build_ssl_connector() -> Result<SslConnector> {
     Ok(builder.build())
 }
 
-fn connect_ws(url: &str) -> Result<Ws> {
-    use tungstenite::client::IntoClientRequest;
+/// Parse a `vsock://CID:PORT/path` URL.
+///
+/// The port defaults to [`varlink_http_bridge::DEFAULT_PORT`] if omitted (`vsock://CID/path`).
+fn parse_vsock_url(url: &str) -> Result<(u32, u32, String)> {
+    let rest = url
+        .strip_prefix("vsock://")
+        .ok_or_else(|| anyhow::anyhow!("not a vsock:// URL"))?;
 
+    // Split authority from path
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+
+    let (cid, port) = varlink_http_bridge::parse_vsock_cid_port(authority)?;
+    Ok((cid, port, path.to_string()))
+}
+
+fn connect_vsock(url: &str) -> Result<(Stream, String, Option<String>)> {
+    let (cid, port, path) = parse_vsock_url(url)?;
+    let stream = vsock::VsockStream::connect_with_cid_port(cid, port)
+        .with_context(|| format!("vsock connect to CID {cid}:{port} failed"))?;
+    let ws_url = format!("ws://vsock{path}");
+    Ok((Stream::Vsock(stream), ws_url, None))
+}
+
+fn connect_tcp(url: &str) -> Result<(Stream, String, Option<String>)> {
     let ws_url = if let Some(rest) = url.strip_prefix("https://") {
         format!("wss://{rest}")
     } else if let Some(rest) = url.strip_prefix("http://") {
@@ -145,23 +202,34 @@ fn connect_ws(url: &str) -> Result<Ws> {
         Stream::Tls(ssl_stream) => Some(varlink_http_bridge::export_tls_channel_binding(
             ssl_stream.ssl(),
         )),
-        Stream::Plain(_) => None,
+        _ => None,
+    };
+
+    Ok((stream, ws_url, tls_channel_binding))
+}
+
+fn connect_ws(url: &str) -> Result<Ws> {
+    use tungstenite::client::IntoClientRequest;
+
+    let (stream, ws_url, tls_channel_binding) = if url.starts_with("vsock://") {
+        connect_vsock(url)?
+    } else {
+        connect_tcp(url)?
     };
 
     // Use into_client_request() here as it auto-generates standard WS upgrade headers,
     // then we add our auth headers too
+    let uri: tungstenite::http::Uri = ws_url.parse().context("invalid WebSocket URL")?;
     let mut request = ws_url
         .into_client_request()
         .context("building WS request")?;
-
     // this adds ssh auth headers if ssh-agent is available, once we have more auth methods
     // it may add more
     maybe_add_auth_headers(&mut request, &uri, tls_channel_binding.as_deref())?;
 
-    let ws_context = if use_tls {
-        "WebSocket handshake failed: check client cert if server requires mTLS"
-    } else {
-        "WebSocket handshake failed"
+    let ws_context = match &stream {
+        Stream::Tls(_) => "WebSocket handshake failed: check client cert if server requires mTLS",
+        _ => "WebSocket handshake failed",
     };
     let (ws, _) = tungstenite::client(request, stream).context(ws_context)?;
     Ok(ws)
@@ -185,10 +253,10 @@ fn forward_ws_until_would_block(ws: &mut Ws, fd3: &mut UnixStream) -> Result<boo
 }
 
 fn graceful_close(ws: &mut Ws) -> Result<()> {
-    let tcp = ws_tcp_stream(ws);
-    tcp.set_nonblocking(false)?;
-    tcp.set_read_timeout(Some(Duration::from_secs(2)))?;
-    tcp.set_write_timeout(Some(Duration::from_secs(2)))?;
+    let stream = ws.get_ref();
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
 
     // close and wait up to aboves timeout
     ws.close(None)?;
@@ -233,7 +301,7 @@ fn main() -> Result<()> {
     // Set non-blocking so that we deal with incomplete websocket
     // frames in ws.read() - they return WouldBlock now and we can
     // continue when waking up from PollFd next time.
-    ws_tcp_stream(&ws).set_nonblocking(true)?;
+    ws.get_ref().set_nonblocking(true)?;
 
     let shutdown = Arc::new(AtomicBool::new(false));
     signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))?;
@@ -247,7 +315,7 @@ fn main() -> Result<()> {
 
         let mut pollfds = [
             PollFd::new(&fd3, PollFlags::IN),
-            PollFd::new(ws_tcp_stream(&ws), PollFlags::IN),
+            PollFd::new(ws.get_ref(), PollFlags::IN),
         ];
         match poll(&mut pollfds, None) {
             // signal interrupted poll: continue to re-check shutdown flag
@@ -281,4 +349,41 @@ fn main() -> Result<()> {
         warn!("WebSocket close failed: {e:#}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_vsock_url_cid_and_port() {
+        let (cid, port, path) =
+            parse_vsock_url("vsock://2:1031/io.systemd.Manager/Describe").unwrap();
+        assert_eq!(cid, 2);
+        assert_eq!(port, 1031);
+        assert_eq!(path, "/io.systemd.Manager/Describe");
+    }
+
+    #[test]
+    fn test_parse_vsock_url_default_port() {
+        let (cid, port, path) = parse_vsock_url("vsock://2/io.systemd.Manager/Describe").unwrap();
+        assert_eq!(cid, 2);
+        assert_eq!(port, varlink_http_bridge::DEFAULT_PORT);
+        assert_eq!(path, "/io.systemd.Manager/Describe");
+    }
+
+    #[test]
+    fn test_parse_vsock_url_no_path() {
+        let (cid, port, path) = parse_vsock_url("vsock://3:5000").unwrap();
+        assert_eq!(cid, 3);
+        assert_eq!(port, 5000);
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn test_parse_vsock_url_errors() {
+        assert!(parse_vsock_url("http://localhost").is_err());
+        assert!(parse_vsock_url("vsock://notanumber:1031/path").is_err());
+        assert!(parse_vsock_url("vsock://2:notaport/path").is_err());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,37 @@ pub const SSHAUTH_MAGIC_PREFIX: [u8; 8] = *b"vhbridge";
 /// token payload to prevent replay attacks.
 pub const SSHAUTH_NONCE_HEADER: &str = "x-auth-nonce";
 
+/// Default port for the HTTP bridge when listening on or connecting via vsock.
+pub const DEFAULT_PORT: u32 = 1031;
+
+/// Parse a `CID:PORT` or bare `CID` string into `(cid, port)`.
+///
+/// If only a single number is given it is treated as the CID and
+/// [`DEFAULT_PORT`] is used.
+///
+/// # Errors
+///
+/// Returns an error if the CID or port cannot be parsed as `u32`.
+pub fn parse_vsock_cid_port(authority: &str) -> anyhow::Result<(u32, u32)> {
+    use anyhow::Context;
+    match authority.split_once(':') {
+        Some((cid_str, port_str)) => Ok((
+            cid_str
+                .parse::<u32>()
+                .with_context(|| format!("invalid vsock CID: {cid_str}"))?,
+            port_str
+                .parse::<u32>()
+                .with_context(|| format!("invalid vsock port: {port_str}"))?,
+        )),
+        None => Ok((
+            authority
+                .parse::<u32>()
+                .with_context(|| format!("invalid vsock CID: {authority}"))?,
+            DEFAULT_PORT,
+        )),
+    }
+}
+
 /// TLS channel binding label per RFC 9266 (`tls-exporter`).
 ///
 /// Both client and server call `export_keying_material()` with this label

--- a/varlink-httpd.spec
+++ b/varlink-httpd.spec
@@ -46,17 +46,18 @@ just build release
 DESTDIR=%{buildroot} SYSCONFDIR=%{_sysconfdir} just install
 
 %post
-%systemd_post varlink-httpd.service varlink-httpd-vsock.socket
+%systemd_post varlink-httpd.service varlink-httpd.socket varlink-httpd-vsock.socket
 
 %preun
-%systemd_preun varlink-httpd.service varlink-httpd-vsock.socket
+%systemd_preun varlink-httpd.service varlink-httpd.socket varlink-httpd-vsock.socket
 
 %postun
-%systemd_postun_with_restart varlink-httpd.service varlink-httpd-vsock.socket
+%systemd_postun_with_restart varlink-httpd.service varlink-httpd.socket varlink-httpd-vsock.socket
 
 %files
 %{_bindir}/varlink-httpd
 %{_unitdir}/varlink-httpd.service
+%{_unitdir}/varlink-httpd.socket
 %{_unitdir}/varlink-httpd-vsock.socket
 %dir %{_sysconfdir}/varlink-httpd
 

--- a/varlink-httpd.spec
+++ b/varlink-httpd.spec
@@ -46,17 +46,18 @@ just build release
 DESTDIR=%{buildroot} SYSCONFDIR=%{_sysconfdir} just install
 
 %post
-%systemd_post varlink-httpd.service
+%systemd_post varlink-httpd.service varlink-httpd-vsock.socket
 
 %preun
-%systemd_preun varlink-httpd.service
+%systemd_preun varlink-httpd.service varlink-httpd-vsock.socket
 
 %postun
-%systemd_postun_with_restart varlink-httpd.service
+%systemd_postun_with_restart varlink-httpd.service varlink-httpd-vsock.socket
 
 %files
 %{_bindir}/varlink-httpd
 %{_unitdir}/varlink-httpd.service
+%{_unitdir}/varlink-httpd-vsock.socket
 %dir %{_sysconfdir}/varlink-httpd
 
 %files -n varlinkctl-http
@@ -64,6 +65,7 @@ DESTDIR=%{buildroot} SYSCONFDIR=%{_sysconfdir} just install
 %{_prefix}/lib/systemd/varlink-bridges/https
 %{_prefix}/lib/systemd/varlink-bridges/ws
 %{_prefix}/lib/systemd/varlink-bridges/wss
+%{_prefix}/lib/systemd/varlink-bridges/vsock
 
 %changelog
 %autochangelog

--- a/varlink-httpd.spec
+++ b/varlink-httpd.spec
@@ -67,6 +67,7 @@ DESTDIR=%{buildroot} SYSCONFDIR=%{_sysconfdir} just install
 %{_prefix}/lib/systemd/varlink-bridges/ws
 %{_prefix}/lib/systemd/varlink-bridges/wss
 %{_prefix}/lib/systemd/varlink-bridges/vsock
+%{_prefix}/lib/systemd/varlink-bridges/vsock+tls
 
 %changelog
 %autochangelog


### PR DESCRIPTION
This PR adds vsock support for the varlink-http-bridge. from the user PoV it looks like this:

Inside the vm (there is also a default data/varlink-httpd-vsock.socket so this can start automaticall):
```console
$ varlink-httpd --bind=vsock --authorized-keys=~/.ssh/authorized_keys
```

And on the host (assume the right ssh keys are available):
```console
$ varlinkctl call vsock://3/ws/sockets/io.systemd.Hostname iio.systemd.Hostname.Describe '{}'
```

