### PR TITLE
httpd: make `--insecure` really skip all authenticators

### DIFF
--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1066,11 +1066,11 @@ async fn main() -> anyhow::Result<()> {
         authenticators.push(Box::new(ssh_auth));
     }
 
-    if authenticators.is_empty() && !has_mtls && !cli.insecure {
-        bail!("no authentication configured: use --authorized-keys=, --trust=, or --insecure");
-    }
-    if cli.insecure && authenticators.is_empty() && !has_mtls {
+    if cli.insecure {
+        authenticators.clear();
         eprintln!("WARNING: running without authentication - all routes are open");
+    } else if authenticators.is_empty() && !has_mtls {
+        bail!("no authentication configured: use --authorized-keys=, --trust=, or --insecure");
     }
 
     let local_addr = listener.local_addr()?;


### PR DESCRIPTION
The current code was a bit silly when --insecure is passed. It would still keep any existing authenticators that got auto-discovered which lead to the confusing effect that a system with configured ssh keys in e.g. /etc/varlink-httpd/authorized_keys would still try to authenticate against those even when `--insecure` is used.

This commit adds a minimal patch to fix this by just clearing all authenticators when `--insecure` is used. This is a minimal fix, I think we want to rework this a bit more but lets start simple for now.

Thanks to Kai report reporting this!