### PR TITLE
httpd: make sshaut use multiple files

### DIFF
--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 use log::{debug, info, warn};
 use ssh_key::{HashAlg, PublicKey};
 use std::collections::HashMap;
@@ -12,7 +12,7 @@ use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER};
 
 struct KeyCache {
     keys: HashMap<String, PublicKey>,
-    mtime: SystemTime,
+    mtimes: HashMap<String, SystemTime>,
 }
 
 /// Tracks recently seen nonces to prevent replay attacks.
@@ -65,32 +65,27 @@ impl NonceStore {
 }
 
 pub(crate) struct SshKeyAuthenticator {
-    path: String,
+    paths: Vec<String>,
     max_skew: u64,
     authorized_keys: Mutex<KeyCache>,
     nonces: Mutex<NonceStore>,
 }
 
 impl SshKeyAuthenticator {
-    pub(crate) fn new(path: &str) -> anyhow::Result<Self> {
-        let keys = Self::load_keys(path)?;
-        // XXX: should we make it a warning only? the file can dynamically
-        // get updated so it could be okay to start empty. OTOH ppl might
-        // be surprised by it.
+    pub(crate) fn new(paths: Vec<String>) -> anyhow::Result<Self> {
+        let (keys, mtimes) = Self::load_all_keys(&paths)?;
         if keys.is_empty() {
-            bail!(
-                "no supported SSH public keys in {path} (note: RSA is not supported, use Ed25519 or ECDSA)"
+            warn!(
+                "no supported SSH public keys in {} (note: RSA is not supported, use Ed25519 or ECDSA); SSH auth will reject all requests until keys appear",
+                paths.join(", "),
             );
         }
-        let mtime = std::fs::metadata(path)
-            .and_then(|m| m.modified())
-            .with_context(|| format!("failed to stat {path}"))?;
 
         let max_skew = 60;
         Ok(Self {
-            path: path.to_string(),
+            paths,
             max_skew,
-            authorized_keys: Mutex::new(KeyCache { keys, mtime }),
+            authorized_keys: Mutex::new(KeyCache { keys, mtimes }),
             nonces: Mutex::new(NonceStore::new(max_skew)),
         })
     }
@@ -132,50 +127,108 @@ impl SshKeyAuthenticator {
         Ok(keys)
     }
 
-    /// Reload the `authorized_keys` file if its mtime has changed.
-    fn maybe_reload(&self) {
-        let current_mtime = match std::fs::metadata(&self.path).and_then(|m| m.modified()) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(
-                    "cannot stat {path}: {e}, keeping cached keys",
-                    path = self.path
-                );
-                return;
-            }
-        };
+    /// Load and merge keys from all paths, returning the merged key map
+    /// and a path->mtime map.  Files that do not (yet) exist are silently
+    /// skipped; they will be picked up by `maybe_reload` once they appear.
+    fn load_all_keys(
+        paths: &[String],
+    ) -> anyhow::Result<(HashMap<String, PublicKey>, HashMap<String, SystemTime>)> {
+        let mut all_keys = HashMap::new();
+        let mut mtimes = HashMap::new();
 
+        for path in paths {
+            let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+                Ok(m) => m,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    info!("authorized keys file {path} does not exist yet, skipping");
+                    continue;
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::new(e).context(format!("failed to stat {path}")));
+                }
+            };
+            let keys = Self::load_keys(path)?;
+            all_keys.extend(keys);
+            mtimes.insert(path.clone(), mtime);
+        }
+
+        Ok((all_keys, mtimes))
+    }
+
+    /// Stat a path, folding `NotFound` into `Ok(None)` so missing files are
+    /// treated as "tracked absence" rather than a hard error.
+    fn stat_mtime(path: &str) -> std::io::Result<Option<SystemTime>> {
+        match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(m) => Ok(Some(m)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Ok(true) if any tracked path's mtime differs from the cache;
+    /// Err carries the path that failed a transient stat so the caller can log it.
+    fn any_mtime_changed(
+        &self,
+        cached: &HashMap<String, SystemTime>,
+    ) -> Result<bool, (String, std::io::Error)> {
+        for path in &self.paths {
+            let mtime = Self::stat_mtime(path).map_err(|e| (path.clone(), e))?;
+            if mtime.as_ref() != cached.get(path) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Reload authorized key files whose mtime has changed.
+    fn maybe_reload(&self) {
         // note that we could use an RWLock here but its probably not worth it
         let mut ak = self.authorized_keys.lock().unwrap();
-        if ak.mtime == current_mtime {
-            return;
+
+        match self.any_mtime_changed(&ak.mtimes) {
+            Ok(false) => {}
+            Ok(true) => self.reload_keys(&mut ak),
+            Err((path, e)) => {
+                // Transient error (permissions, IO): skip this reload cycle
+                // rather than risk dropping valid keys. Retry next request.
+                warn!("cannot stat {path}: {e}, skipping reload (keeping cached keys)");
+            }
+        }
+    }
+
+    /// Reload all tracked paths into `ak`, replacing its cached keys and mtimes.
+    fn reload_keys(&self, ak: &mut KeyCache) {
+        let mut merged_keys = HashMap::new();
+        let mut new_mtimes = HashMap::new();
+        for path in &self.paths {
+            let Ok(Some(mtime)) = Self::stat_mtime(path) else {
+                continue; // file is gone or unreadable; drop its cached keys
+            };
+            match Self::load_keys(path) {
+                Ok(keys) => {
+                    info!(
+                        "reloaded {count} SSH key(s) from {path} (file changed)",
+                        count = keys.len(),
+                    );
+                    merged_keys.extend(keys);
+                }
+                Err(e) => {
+                    warn!("failed to reload {path}: {e:#}, skipping this source");
+                }
+            }
+            new_mtimes.insert(path.clone(), mtime);
         }
 
-        match Self::load_keys(&self.path) {
-            Ok(keys) => {
-                info!(
-                    "reloaded {count} SSH key(s) from {path} (file changed)",
-                    count = keys.len(),
-                    path = self.path,
-                );
-                if keys.is_empty() {
-                    warn!(
-                        "authorized keys file {path} is empty, SSH auth will reject all requests",
-                        path = self.path,
-                    );
-                }
-                ak.keys = keys;
-                ak.mtime = current_mtime;
-            }
-            Err(e) => {
-                warn!(
-                    "failed to reload {path}: {e:#}, clearing keys (fail closed)",
-                    path = self.path,
-                );
-                ak.keys.clear();
-                ak.mtime = current_mtime;
-            }
+        if merged_keys.is_empty() {
+            warn!("all authorized key sources are empty, SSH auth will reject all requests");
         }
+        ak.keys = merged_keys;
+        ak.mtimes = new_mtimes;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reload_for_test(&self) {
+        self.maybe_reload();
     }
 }
 
@@ -184,7 +237,7 @@ impl std::fmt::Debug for SshKeyAuthenticator {
         let ak = self.authorized_keys.lock().unwrap();
         let fingerprints: Vec<&str> = ak.keys.keys().map(String::as_str).collect();
         f.debug_struct("SshKeyAuthenticator")
-            .field("path", &self.path)
+            .field("paths", &self.paths)
             .field("max_skew", &self.max_skew)
             .field("fingerprints", &fingerprints)
             .finish_non_exhaustive()
@@ -207,36 +260,38 @@ const SSH_AUTHORIZED_KEYS_CREDENTIALS: &[&str] = &[
     "ssh.ephemeral-authorized_keys-all",
 ];
 
-pub(crate) fn maybe_create_ssh_authenticator(
+pub(crate) fn create_ssh_authenticator(
     cli_authorized_keys: Option<String>,
     creds_dir: Option<&std::path::Path>,
     root: &std::path::Path,
-) -> anyhow::Result<Option<SshKeyAuthenticator>> {
-    fn exists(p: &std::path::Path) -> Option<String> {
-        p.exists().then(|| p.to_string_lossy().to_string())
-    }
-
-    // Priority: explicit CLI > /etc config > $CREDENTIALS_DIRECTORY
-    // (ImportCredential= in the unit file handles system-wide credentials)
-    let authorized_keys_path = cli_authorized_keys
-        .or_else(|| exists(&root.join("etc/varlink-httpd/authorized_keys")))
-        .or_else(|| {
-            creds_dir.and_then(|d| {
-                SSH_AUTHORIZED_KEYS_CREDENTIALS
-                    .iter()
-                    .find_map(|name| exists(&d.join(name)))
-            })
-        });
-
-    let Some(ak_path) = authorized_keys_path else {
-        return Ok(None);
+) -> anyhow::Result<SshKeyAuthenticator> {
+    let paths: Vec<String> = if let Some(cli_path) = cli_authorized_keys {
+        // Explicit CLI path overrides all auto-discovery
+        vec![cli_path]
+    } else {
+        // Register all well-known sources; files that don't exist yet
+        // will be picked up by maybe_reload() once they appear.
+        let mut paths = Vec::new();
+        paths.push(
+            root.join("etc/varlink-httpd/authorized_keys")
+                .to_string_lossy()
+                .to_string(),
+        );
+        if let Some(d) = creds_dir {
+            for name in SSH_AUTHORIZED_KEYS_CREDENTIALS {
+                paths.push(d.join(name).to_string_lossy().to_string());
+            }
+        }
+        paths
     };
-    let ssh_auth = SshKeyAuthenticator::new(&ak_path)?;
+
+    let ssh_auth = SshKeyAuthenticator::new(paths.clone())?;
     info!(
-        "Authenticator: adding SSH authorized keys ({count} keys from {ak_path})",
-        count = ssh_auth.key_count()
+        "Authenticator: adding SSH authorized keys ({count} keys from {sources})",
+        count = ssh_auth.key_count(),
+        sources = paths.join(", "),
     );
-    Ok(Some(ssh_auth))
+    Ok(ssh_auth)
 }
 
 impl Authenticator for SshKeyAuthenticator {

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -3,16 +3,186 @@
 use anyhow::Context;
 use log::{debug, info, warn};
 use ssh_key::{HashAlg, PublicKey};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
 use crate::Authenticator;
 use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER};
 
-struct KeyCache {
+/// One tracked `authorized_keys` file: its mtime when last read and the
+/// (fingerprint -> key) map of supported keys it contained. Bundling
+/// these avoids having to keep the per-path mtime in a second map in
+/// lockstep with the keys.
+struct AuthKeysFile {
+    mtime: SystemTime,
     keys: HashMap<String, PublicKey>,
-    mtimes: HashMap<String, SystemTime>,
+}
+
+impl AuthKeysFile {
+    /// Stat `path`, folding `NotFound` into `Ok(None)` so missing files are
+    /// treated as "tracked absence" rather than a hard error.
+    fn stat_mtime(path: &str) -> std::io::Result<Option<SystemTime>> {
+        match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(m) => Ok(Some(m)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Parse an `authorized_keys` file, returning only supported (non-RSA) keys.
+    fn parse_keys(path: &str) -> anyhow::Result<HashMap<String, PublicKey>> {
+        let keys_vec = sshauth::keyfile::parse_authorized_keys(path, true)
+            .with_context(|| format!("failed to read authorized keys from {path}"))?;
+
+        let mut keys = HashMap::new();
+        for key in keys_vec {
+            if matches!(key.algorithm(), ssh_key::Algorithm::Rsa { .. }) {
+                warn!(
+                    "ignoring RSA key {} ({}): RSA signing is not supported, use Ed25519 or ECDSA",
+                    key.fingerprint(HashAlg::Sha256),
+                    key.comment(),
+                );
+                continue;
+            }
+            let fp = key.fingerprint(HashAlg::Sha256).to_string();
+            debug!(
+                "  authorized key: {fp} ({comment})",
+                comment = key.comment()
+            );
+            keys.insert(fp, key);
+        }
+        Ok(keys)
+    }
+
+    /// Stat and parse `path`. Returns `Ok(None)` if the file does not
+    /// exist yet (it will be picked up by `maybe_reload` once it appears).
+    fn load(path: &str) -> anyhow::Result<Option<Self>> {
+        let mtime = match Self::stat_mtime(path) {
+            Ok(Some(m)) => m,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(format!("failed to stat {path}")));
+            }
+        };
+        let keys = Self::parse_keys(path)?;
+        Ok(Some(Self { mtime, keys }))
+    }
+}
+
+struct KeyCache {
+    files: HashMap<String, AuthKeysFile>,
+}
+
+impl KeyCache {
+    /// Initial load of all tracked paths. Files that do not (yet) exist
+    /// are silently skipped; they will be picked up by `reload` once
+    /// they appear. Parse errors propagate (startup should fail loud).
+    fn load_all(paths: &[String]) -> anyhow::Result<Self> {
+        let mut files = HashMap::new();
+        for path in paths {
+            match AuthKeysFile::load(path)? {
+                Some(f) => {
+                    files.insert(path.clone(), f);
+                }
+                None => info!("authorized keys file {path} does not exist yet, skipping"),
+            }
+        }
+        Ok(Self { files })
+    }
+
+    /// Number of distinct key fingerprints across all tracked files.
+    fn unique_key_count(&self) -> usize {
+        let mut fps: HashSet<&str> = HashSet::new();
+        for f in self.files.values() {
+            fps.extend(f.keys.keys().map(String::as_str));
+        }
+        fps.len()
+    }
+
+    /// All keys across all tracked files, deduplicated by fingerprint
+    /// (a key listed in more than one file is returned once).
+    fn all_keys(&self) -> Vec<PublicKey> {
+        let mut by_fp: HashMap<&str, PublicKey> = HashMap::new();
+        for f in self.files.values() {
+            for (fp, key) in &f.keys {
+                by_fp.entry(fp.as_str()).or_insert_with(|| key.clone());
+            }
+        }
+        by_fp.into_values().collect()
+    }
+
+    /// All unique fingerprints currently cached, across all tracked files.
+    fn fingerprints(&self) -> Vec<&str> {
+        let fps: HashSet<&str> = self
+            .files
+            .values()
+            .flat_map(|f| f.keys.keys().map(String::as_str))
+            .collect();
+        fps.into_iter().collect()
+    }
+
+    /// Ok(true) if any `path` in `paths` has an mtime that differs from
+    /// what this cache has recorded (including "file now exists" and
+    /// "file now gone"). Err carries the path that failed a transient
+    /// stat so the caller can log it.
+    fn any_mtime_changed(&self, paths: &[String]) -> Result<bool, (String, std::io::Error)> {
+        for path in paths {
+            let now = AuthKeysFile::stat_mtime(path).map_err(|e| (path.clone(), e))?;
+            let cached = self.files.get(path).map(|f| f.mtime);
+            if now != cached {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// If any tracked path has changed on disk, re-read it; transient
+    /// stat errors are logged and the cache is left untouched (retried
+    /// on the next call).
+    fn maybe_reload(&mut self, paths: &[String]) {
+        match self.any_mtime_changed(paths) {
+            Ok(false) => {}
+            Ok(true) => self.reload(paths),
+            Err((path, e)) => {
+                // Transient error (permissions, IO): skip this reload cycle
+                // rather than risk dropping valid keys. Retry next request.
+                warn!("cannot stat {path}: {e}, skipping reload (keeping cached keys)");
+            }
+        }
+    }
+
+    /// Re-read all `paths` into this cache, replacing previously tracked
+    /// entries. On parse errors the file's mtime is still recorded (with
+    /// empty keys) so we don't log-spam the same warning on every request
+    /// until the file changes again.
+    fn reload(&mut self, paths: &[String]) {
+        let mut new_files = HashMap::new();
+        for path in paths {
+            let Ok(Some(mtime)) = AuthKeysFile::stat_mtime(path) else {
+                continue; // file is gone or unreadable; drop its cached keys
+            };
+            let keys = match AuthKeysFile::parse_keys(path) {
+                Ok(keys) => {
+                    info!(
+                        "reloaded {count} SSH key(s) from {path} (file changed)",
+                        count = keys.len(),
+                    );
+                    keys
+                }
+                Err(e) => {
+                    warn!("failed to reload {path}: {e:#}, skipping this source");
+                    HashMap::new()
+                }
+            };
+            new_files.insert(path.clone(), AuthKeysFile { mtime, keys });
+        }
+
+        self.files = new_files;
+        if self.unique_key_count() == 0 {
+            warn!("all authorized key sources are empty, SSH auth will reject all requests");
+        }
+    }
 }
 
 /// Tracks recently seen nonces to prevent replay attacks.
@@ -73,8 +243,8 @@ pub(crate) struct SshKeyAuthenticator {
 
 impl SshKeyAuthenticator {
     pub(crate) fn new(paths: Vec<String>) -> anyhow::Result<Self> {
-        let (keys, mtimes) = Self::load_all_keys(&paths)?;
-        if keys.is_empty() {
+        let cache = KeyCache::load_all(&paths)?;
+        if cache.unique_key_count() == 0 {
             warn!(
                 "no supported SSH public keys in {} (note: RSA is not supported, use Ed25519 or ECDSA); SSH auth will reject all requests until keys appear",
                 paths.join(", "),
@@ -85,13 +255,13 @@ impl SshKeyAuthenticator {
         Ok(Self {
             paths,
             max_skew,
-            authorized_keys: Mutex::new(KeyCache { keys, mtimes }),
+            authorized_keys: Mutex::new(cache),
             nonces: Mutex::new(NonceStore::new(max_skew)),
         })
     }
 
     pub(crate) fn key_count(&self) -> usize {
-        self.authorized_keys.lock().unwrap().keys.len()
+        self.authorized_keys.lock().unwrap().unique_key_count()
     }
 
     #[cfg(test)]
@@ -101,141 +271,19 @@ impl SshKeyAuthenticator {
         self
     }
 
-    /// Parse an `authorized_keys` file, returning only supported (non-RSA) keys.
-    fn load_keys(path: &str) -> anyhow::Result<HashMap<String, PublicKey>> {
-        let keys_vec = sshauth::keyfile::parse_authorized_keys(path, true)
-            .with_context(|| format!("failed to read authorized keys from {path}"))?;
-
-        let mut keys = HashMap::new();
-        for key in keys_vec {
-            if matches!(key.algorithm(), ssh_key::Algorithm::Rsa { .. }) {
-                warn!(
-                    "ignoring RSA key {} ({}): RSA signing is not supported, use Ed25519 or ECDSA",
-                    key.fingerprint(HashAlg::Sha256),
-                    key.comment(),
-                );
-                continue;
-            }
-            let fp = key.fingerprint(HashAlg::Sha256).to_string();
-            debug!(
-                "  authorized key: {fp} ({comment})",
-                comment = key.comment()
-            );
-            keys.insert(fp, key);
-        }
-
-        Ok(keys)
-    }
-
-    /// Load and merge keys from all paths, returning the merged key map
-    /// and a path->mtime map.  Files that do not (yet) exist are silently
-    /// skipped; they will be picked up by `maybe_reload` once they appear.
-    fn load_all_keys(
-        paths: &[String],
-    ) -> anyhow::Result<(HashMap<String, PublicKey>, HashMap<String, SystemTime>)> {
-        let mut all_keys = HashMap::new();
-        let mut mtimes = HashMap::new();
-
-        for path in paths {
-            let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
-                Ok(m) => m,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    info!("authorized keys file {path} does not exist yet, skipping");
-                    continue;
-                }
-                Err(e) => {
-                    return Err(anyhow::Error::new(e).context(format!("failed to stat {path}")));
-                }
-            };
-            let keys = Self::load_keys(path)?;
-            all_keys.extend(keys);
-            mtimes.insert(path.clone(), mtime);
-        }
-
-        Ok((all_keys, mtimes))
-    }
-
-    /// Stat a path, folding `NotFound` into `Ok(None)` so missing files are
-    /// treated as "tracked absence" rather than a hard error.
-    fn stat_mtime(path: &str) -> std::io::Result<Option<SystemTime>> {
-        match std::fs::metadata(path).and_then(|m| m.modified()) {
-            Ok(m) => Ok(Some(m)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Ok(true) if any tracked path's mtime differs from the cache;
-    /// Err carries the path that failed a transient stat so the caller can log it.
-    fn any_mtime_changed(
-        &self,
-        cached: &HashMap<String, SystemTime>,
-    ) -> Result<bool, (String, std::io::Error)> {
-        for path in &self.paths {
-            let mtime = Self::stat_mtime(path).map_err(|e| (path.clone(), e))?;
-            if mtime.as_ref() != cached.get(path) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    /// Reload authorized key files whose mtime has changed.
-    fn maybe_reload(&self) {
-        // note that we could use an RWLock here but its probably not worth it
-        let mut ak = self.authorized_keys.lock().unwrap();
-
-        match self.any_mtime_changed(&ak.mtimes) {
-            Ok(false) => {}
-            Ok(true) => self.reload_keys(&mut ak),
-            Err((path, e)) => {
-                // Transient error (permissions, IO): skip this reload cycle
-                // rather than risk dropping valid keys. Retry next request.
-                warn!("cannot stat {path}: {e}, skipping reload (keeping cached keys)");
-            }
-        }
-    }
-
-    /// Reload all tracked paths into `ak`, replacing its cached keys and mtimes.
-    fn reload_keys(&self, ak: &mut KeyCache) {
-        let mut merged_keys = HashMap::new();
-        let mut new_mtimes = HashMap::new();
-        for path in &self.paths {
-            let Ok(Some(mtime)) = Self::stat_mtime(path) else {
-                continue; // file is gone or unreadable; drop its cached keys
-            };
-            match Self::load_keys(path) {
-                Ok(keys) => {
-                    info!(
-                        "reloaded {count} SSH key(s) from {path} (file changed)",
-                        count = keys.len(),
-                    );
-                    merged_keys.extend(keys);
-                }
-                Err(e) => {
-                    warn!("failed to reload {path}: {e:#}, skipping this source");
-                }
-            }
-            new_mtimes.insert(path.clone(), mtime);
-        }
-
-        if merged_keys.is_empty() {
-            warn!("all authorized key sources are empty, SSH auth will reject all requests");
-        }
-        ak.keys = merged_keys;
-        ak.mtimes = new_mtimes;
-    }
-
     #[cfg(test)]
     pub(crate) fn reload_for_test(&self) {
-        self.maybe_reload();
+        self.authorized_keys
+            .lock()
+            .unwrap()
+            .maybe_reload(&self.paths);
     }
 }
 
 impl std::fmt::Debug for SshKeyAuthenticator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ak = self.authorized_keys.lock().unwrap();
-        let fingerprints: Vec<&str> = ak.keys.keys().map(String::as_str).collect();
+        let fingerprints = ak.fingerprints();
         f.debug_struct("SshKeyAuthenticator")
             .field("paths", &self.paths)
             .field("max_skew", &self.max_skew)
@@ -303,7 +351,10 @@ impl Authenticator for SshKeyAuthenticator {
         nonce: Option<&str>,
         tls_channel_binding: Option<&str>,
     ) -> anyhow::Result<()> {
-        self.maybe_reload();
+        self.authorized_keys
+            .lock()
+            .unwrap()
+            .maybe_reload(&self.paths);
 
         let nonce = nonce.context("missing nonce header (x-auth-nonce)")?;
 
@@ -318,7 +369,7 @@ impl Authenticator for SshKeyAuthenticator {
         // held during the (slow) verify_for()
         let authorized_keys: Vec<ssh_key::PublicKey> = {
             let ak = self.authorized_keys.lock().unwrap();
-            ak.keys.values().cloned().collect()
+            ak.all_keys()
         };
 
         let verified = unverified_token

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -35,7 +35,7 @@ mod auth_ssh;
 mod import_ssh;
 
 #[cfg(feature = "sshauth")]
-use auth_ssh::{extract_nonce, maybe_create_ssh_authenticator};
+use auth_ssh::{create_ssh_authenticator, extract_nonce};
 #[cfg(not(feature = "sshauth"))]
 fn extract_nonce(_headers: &axum::http::HeaderMap) -> Option<String> {
     None
@@ -1029,7 +1029,7 @@ fn parse_cli() -> anyhow::Result<Command> {
                 return parse_import_ssh_args(&mut parser);
             }
             Value(val) if !got_positional && val == "bridge" => {
-                // explicit "bridge" subcommand — just consume the keyword
+                // explicit "bridge" subcommand, just consume the keyword
                 got_positional = false;
             }
             Value(val) if !got_positional => {
@@ -1114,11 +1114,12 @@ async fn main() -> anyhow::Result<()> {
     let mut authenticators: Vec<Box<dyn Authenticator>> = Vec::new();
 
     #[cfg(feature = "sshauth")]
-    if let Some(ssh_auth) = maybe_create_ssh_authenticator(
-        cli.authorized_keys,
-        creds_dir.as_deref(),
-        std::path::Path::new("/"),
-    )? {
+    {
+        let ssh_auth = create_ssh_authenticator(
+            cli.authorized_keys,
+            creds_dir.as_deref(),
+            std::path::Path::new("/"),
+        )?;
         authenticators.push(Box::new(ssh_auth));
     }
 
@@ -1126,7 +1127,10 @@ async fn main() -> anyhow::Result<()> {
         authenticators.clear();
         eprintln!("WARNING: running without authentication - all routes are open");
     } else if authenticators.is_empty() && !has_mtls {
-        bail!("no authentication configured: use --authorized-keys=, --trust=, or --insecure");
+        #[cfg(not(feature = "sshauth"))]
+        bail!(
+            "no authentication configured: build with 'sshauth' feature, use --trust=, or --insecure"
+        );
     }
 
     let local_addr = listener.local_addr()?;

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1061,7 +1061,7 @@ async fn test_tls_credentials_directory_fallback() {
     std::fs::copy(&pki.server_cert_path, creds_dir.path().join("cert")).unwrap();
     std::fs::copy(&pki.server_key_path, creds_dir.path().join("key")).unwrap();
 
-    // No CLI flags — resolve_tls_acceptor should pick up creds from the directory
+    // No CLI flags; resolve_tls_acceptor should pick up creds from the directory
     let acceptor = resolve_tls_acceptor(None, None, None, Some(creds_dir.path()))
         .expect("credentials directory fallback failed")
         .expect("expected Some(acceptor) from credentials directory");
@@ -1254,7 +1254,7 @@ fn test_format_x509_subject_multiple_fields() {
 #[cfg(feature = "sshauth")]
 mod sshauth_tests {
     use super::*;
-    use crate::maybe_create_ssh_authenticator;
+    use crate::create_ssh_authenticator;
 
     /// Create a fake rootdir with an `etc/varlink-httpd/authorized_keys` file.
     fn make_test_rootdir_with_keys(pubkeys: &[&str]) -> tempfile::TempDir {
@@ -1291,9 +1291,7 @@ mod sshauth_tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
         let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
+        let auth = create_ssh_authenticator(None, None, root.path()).unwrap();
         // Leak both tempdirs so they live for the test duration.
         // (The keypair dir and the rootdir with authorized_keys.)
         std::mem::forget(tmpdir);
@@ -1339,27 +1337,58 @@ mod sshauth_tests {
 
         let pub_key_content = std::fs::read_to_string(key_path.with_extension("pub")).unwrap();
         let root = make_test_rootdir_with_keys(&[pub_key_content.trim()]);
-        let result = maybe_create_ssh_authenticator(None, None, root.path());
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("RSA is not supported"),
-            "RSA-only authorized_keys should fail with clear message"
+        let auth = create_ssh_authenticator(None, None, root.path()).unwrap();
+        assert_eq!(
+            auth.key_count(),
+            0,
+            "RSA-only authorized_keys should have 0 usable keys"
         );
     }
 
     #[test]
-    fn test_ssh_auth_rejects_garbage() {
+    fn test_ssh_auth_accepts_garbage() {
         let root = make_test_rootdir_with_keys(&["not-a-real-key line", "# comment"]);
-        let result = maybe_create_ssh_authenticator(None, None, root.path());
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("no supported SSH public keys")
+        let auth = create_ssh_authenticator(None, None, root.path()).unwrap();
+        assert_eq!(
+            auth.key_count(),
+            0,
+            "garbage authorized_keys should have 0 usable keys"
+        );
+    }
+
+    #[test]
+    fn test_ssh_auth_drops_keys_when_file_removed() {
+        let keydir_a = tempfile::tempdir().unwrap();
+        let keydir_b = tempfile::tempdir().unwrap();
+        let (pubkey_a, _) = generate_ed25519_keypair(keydir_a.path());
+        let (pubkey_b, _) = generate_ed25519_keypair(keydir_b.path());
+
+        let file_a = keydir_a.path().join("authorized_keys");
+        let file_b = keydir_b.path().join("authorized_keys");
+        std::fs::write(&file_a, pubkey_a.as_bytes()).unwrap();
+        std::fs::write(&file_b, pubkey_b.as_bytes()).unwrap();
+
+        let auth = crate::auth_ssh::SshKeyAuthenticator::new(vec![
+            file_a.to_string_lossy().into_owned(),
+            file_b.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+        assert_eq!(auth.key_count(), 2);
+
+        std::fs::remove_file(&file_b).unwrap();
+        auth.reload_for_test();
+        assert_eq!(
+            auth.key_count(),
+            1,
+            "key from removed file should be dropped"
+        );
+
+        std::fs::remove_file(&file_a).unwrap();
+        auth.reload_for_test();
+        assert_eq!(
+            auth.key_count(),
+            0,
+            "all keys should be dropped when every source is removed"
         );
     }
 
@@ -1389,7 +1418,7 @@ mod sshauth_tests {
         // Key A: in authorized_keys
         let (auth, _) = make_test_ssh_auth();
 
-        // Key B: NOT in authorized_keys — sign with this one
+        // Key B: NOT in authorized_keys; sign with this one
         let tmpdir_b = tempfile::tempdir().unwrap();
         let (_, key_path_b) = generate_ed25519_keypair(tmpdir_b.path());
         let signer = make_test_token_signer(&key_path_b);
@@ -1657,16 +1686,14 @@ mod sshauth_tests {
         let keygen_dir_b2 = tempfile::tempdir().unwrap();
         let (pubkey_b2, _) = generate_ed25519_keypair(keygen_dir_b2.path());
 
-        // 1. Empty rootdir + no creds_dir → None
+        // 1. Empty rootdir + no creds_dir → authenticator with 0 keys (waiting for files)
         let empty_root = tempfile::tempdir().unwrap();
-        let result = maybe_create_ssh_authenticator(None, None, empty_root.path()).unwrap();
-        assert!(result.is_none(), "empty rootdir should yield None");
+        let auth = create_ssh_authenticator(None, None, empty_root.path()).unwrap();
+        assert_eq!(auth.key_count(), 0, "empty rootdir should yield 0 keys");
 
         // 2. rootdir/etc/varlink-httpd/authorized_keys exists → found
         let root = make_test_rootdir_with_keys(&[pubkey_a.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
+        let auth = create_ssh_authenticator(None, None, root.path()).unwrap();
         assert_eq!(auth.key_count(), 1, "should find key from /etc path");
 
         // 3. $CREDENTIALS_DIRECTORY/ssh.authorized_keys.root exists → found
@@ -1676,12 +1703,11 @@ mod sshauth_tests {
             pubkey_a.as_bytes(),
         )
         .unwrap();
-        let auth = maybe_create_ssh_authenticator(None, Some(creds_dir.path()), empty_root.path())
-            .unwrap()
-            .unwrap();
+        let auth =
+            create_ssh_authenticator(None, Some(creds_dir.path()), empty_root.path()).unwrap();
         assert_eq!(auth.key_count(), 1, "should find key from creds_dir");
 
-        // 4. Both /etc and $CREDENTIALS_DIRECTORY exist → /etc takes priority
+        // 4. Both /etc and $CREDENTIALS_DIRECTORY exist → keys are merged
         let root_both = tempfile::tempdir().unwrap();
         let etc_dir = root_both.path().join("etc/varlink-httpd");
         std::fs::create_dir_all(&etc_dir).unwrap();
@@ -1692,13 +1718,12 @@ mod sshauth_tests {
         writeln!(creds_file, "{}", pubkey_b1.trim()).unwrap();
         writeln!(creds_file, "{}", pubkey_b2.trim()).unwrap();
         drop(creds_file);
-        let auth = maybe_create_ssh_authenticator(None, Some(creds_dir_b.path()), root_both.path())
-            .unwrap()
-            .unwrap();
+        let auth =
+            create_ssh_authenticator(None, Some(creds_dir_b.path()), root_both.path()).unwrap();
         assert_eq!(
             auth.key_count(),
-            1,
-            "/etc (1 key) should take priority over creds_dir (2 keys)"
+            3,
+            "/etc (1 key) + creds_dir (2 keys) should be merged"
         );
 
         // 5b. ssh.ephemeral-authorized_keys-all is used when .root is absent (creds_dir)
@@ -1711,12 +1736,10 @@ mod sshauth_tests {
         )
         .unwrap();
         let auth =
-            maybe_create_ssh_authenticator(None, Some(creds_dir_all.path()), empty_root.path())
-                .unwrap()
-                .unwrap();
+            create_ssh_authenticator(None, Some(creds_dir_all.path()), empty_root.path()).unwrap();
         assert_eq!(auth.key_count(), 1, "should find key from .all credential");
 
-        // 5c. ssh.authorized_keys.root takes priority over .all (creds_dir)
+        // 5c. Both .root and .all credentials exist → keys are merged
         let creds_dir_both = tempfile::tempdir().unwrap();
         std::fs::write(
             creds_dir_both.path().join("ssh.authorized_keys.root"),
@@ -1733,27 +1756,27 @@ mod sshauth_tests {
         writeln!(all_file, "{}", pubkey_b2.trim()).unwrap();
         drop(all_file);
         let auth =
-            maybe_create_ssh_authenticator(None, Some(creds_dir_both.path()), empty_root.path())
-                .unwrap()
-                .unwrap();
+            create_ssh_authenticator(None, Some(creds_dir_both.path()), empty_root.path()).unwrap();
         assert_eq!(
             auth.key_count(),
-            1,
-            ".root (1 key) should take priority over .all (2 keys)"
+            3,
+            ".root (1 key) + .all (2 keys) should be merged"
         );
 
-        // 6. CLI path overrides everything
+        // 6. CLI path overrides everything (only CLI path is used)
         let cli_root = make_test_rootdir_with_keys(&[pubkey_a.trim()]);
         let cli_file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(cli_file.path(), "not-a-real-key garbage\n").unwrap();
-        let result = maybe_create_ssh_authenticator(
+        std::fs::write(cli_file.path(), format!("{}\n", pubkey_b1.trim())).unwrap();
+        let auth = create_ssh_authenticator(
             Some(cli_file.path().to_str().unwrap().to_string()),
             Some(creds_dir.path()),
             cli_root.path(),
-        );
-        assert!(
-            result.is_err(),
-            "CLI path should be used, not /etc or credential"
+        )
+        .unwrap();
+        assert_eq!(
+            auth.key_count(),
+            1,
+            "CLI path should be used exclusively, not /etc or credential"
         );
     }
 


### PR DESCRIPTION
This commit ensures that sshauth checks all files that may contain ssh keys like /etc/varlink-httpd/authorized_keys and the credentials for matching keys. It will also no longer die when no keys are found but instead keep waiting for other authentication sources to appear.

This is fine because we are socket activated anyway and it avoid a failure on a fresh VM that has no authentication but a running varlink-httpd which currently just fails in this setup.