### PR TITLE
.gitignore: Add Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 mkosi.tools
 mkosi.tools.manifest
 *.list
+Cargo.lock


### PR DESCRIPTION
As long as Cargo.lock is not tracked in git we should have it in .gitignore because the tree is otherwise not clean after building.