### PR TITLE
httpd: make open access explicit via AllowAllAuthenticator

### DIFF
--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -347,7 +347,7 @@ impl Authenticator for SshKeyAuthenticator {
         &self,
         method: &str,
         path: &str,
-        auth_header: &str,
+        auth_header: Option<&str>,
         nonce: Option<&str>,
         tls_channel_binding: Option<&str>,
     ) -> anyhow::Result<()> {
@@ -356,6 +356,7 @@ impl Authenticator for SshKeyAuthenticator {
             .unwrap()
             .maybe_reload(&self.paths);
 
+        let auth_header = auth_header.context("missing Authorization header")?;
         let nonce = nonce.context("missing nonce header (x-auth-nonce)")?;
 
         let token_str = auth_header

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -532,10 +532,36 @@ trait Authenticator: Send + Sync {
         &self,
         method: &str,
         path: &str,
-        auth_header: &str,
+        auth_header: Option<&str>,
         nonce: Option<&str>,
         channel_binding: Option<&str>,
     ) -> anyhow::Result<()>;
+}
+
+/// Authenticator that accepts every request.
+///
+/// Pushed explicitly when authentication is delegated to a lower layer
+/// (mTLS verified during the TLS handshake) or deliberately disabled
+/// (`--insecure`). Making this an explicit authenticator keeps the
+/// middleware fail-closed: an empty `authenticators` list always rejects,
+/// so no future code path can accidentally turn into open access by
+/// failing to push a real authenticator.
+struct AllowAllAuthenticator {
+    reason: &'static str,
+}
+
+impl Authenticator for AllowAllAuthenticator {
+    fn check_request(
+        &self,
+        method: &str,
+        path: &str,
+        _auth_header: Option<&str>,
+        _nonce: Option<&str>,
+        _channel_binding: Option<&str>,
+    ) -> anyhow::Result<()> {
+        debug!("auth: allowing {method} {path} ({})", self.reason);
+        Ok(())
+    }
 }
 
 /// Extract the Authorization header value, if present and valid UTF-8.
@@ -553,23 +579,7 @@ async fn auth_middleware(
     request: axum::http::Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    if state.authenticators.is_empty() {
-        debug!("auth: no authenticators configured, allowing request");
-        return next.run(request).await;
-    }
-
-    let Some(auth_header) = extract_auth_header(&request) else {
-        debug!(
-            "auth: missing or invalid Authorization header in request to {}",
-            request.uri()
-        );
-        return (
-            StatusCode::UNAUTHORIZED,
-            axum::Json(json!({"error": "missing Authorization header"})),
-        )
-            .into_response();
-    };
-
+    let auth_header = extract_auth_header(&request);
     let nonce = extract_nonce(request.headers());
 
     let tls_channel_binding: Option<String> = request
@@ -591,7 +601,7 @@ async fn auth_middleware(
         match authenticator.check_request(
             &method,
             &path,
-            &auth_header,
+            auth_header.as_deref(),
             nonce.as_deref(),
             tls_channel_binding.as_deref(),
         ) {
@@ -603,7 +613,11 @@ async fn auth_middleware(
         }
     }
 
-    let joined = errors.join("; ");
+    let joined = if errors.is_empty() {
+        "no authenticators configured".to_string()
+    } else {
+        errors.join("; ")
+    };
     debug!("auth: rejected {method} {path}: {joined}");
     (
         StatusCode::UNAUTHORIZED,
@@ -1302,12 +1316,23 @@ async fn main() -> anyhow::Result<()> {
 
     if cli.insecure {
         authenticators.clear();
+        authenticators.push(Box::new(AllowAllAuthenticator {
+            reason: "--insecure",
+        }));
         eprintln!("WARNING: running without authentication - all routes are open");
-    } else if authenticators.is_empty() && !has_mtls {
-        #[cfg(not(feature = "sshauth"))]
-        bail!(
-            "no authentication configured: build with 'sshauth' feature, use --trust=, or --insecure"
-        );
+    } else if authenticators.is_empty() {
+        if has_mtls {
+            // mTLS verifies the client during the TLS handshake; no
+            // additional per-request HTTP authentication is needed.
+            authenticators.push(Box::new(AllowAllAuthenticator {
+                reason: "mTLS verified at TLS layer",
+            }));
+        } else {
+            #[cfg(not(feature = "sshauth"))]
+            bail!(
+                "no authentication configured: build with 'sshauth' feature, use --trust=, or --insecure"
+            );
+        }
     }
 
     let app = create_router(&cli.varlink_sockets_path, authenticators)?;

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -76,7 +76,11 @@ fn helper_binary() -> std::path::PathBuf {
 }
 
 async fn run_test_server(varlink_sockets_path: &str) -> TestServer<std::net::SocketAddr> {
-    run_test_server_with_auth(varlink_sockets_path, Vec::new()).await
+    run_test_server_with_auth(
+        varlink_sockets_path,
+        vec![Box::new(crate::AllowAllAuthenticator { reason: "test" })],
+    )
+    .await
 }
 
 async fn run_test_server_with_auth(
@@ -1514,7 +1518,7 @@ mod sshauth_tests {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), None);
+        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), None);
         assert!(result.is_err(), "expired token should be rejected");
     }
 
@@ -1536,7 +1540,7 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), None);
+        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), None);
         assert!(result.is_err());
         assert!(
             result
@@ -1562,7 +1566,7 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
             .expect("valid ed25519 token should pass");
     }
 
@@ -1620,7 +1624,7 @@ mod sshauth_tests {
             &self,
             _method: &str,
             _path: &str,
-            _auth_header: &str,
+            _auth_header: Option<&str>,
             _nonce: Option<&str>,
             _channel_binding: Option<&str>,
         ) -> anyhow::Result<()> {
@@ -1672,17 +1676,36 @@ mod sshauth_tests {
     }
 
     #[tokio::test]
-    async fn test_ssh_auth_no_authenticators_allows_all() {
+    async fn test_no_authenticators_rejects_all() {
         use axum::body::Body;
         use axum::http::Request;
         use tower::ServiceExt;
 
+        // An empty authenticator list must fail closed: open access is
+        // only allowed when an explicit AllowAllAuthenticator is pushed.
         let app = make_auth_test_router(Vec::new());
         let response = app
             .oneshot(Request::get("/sockets").body(Body::empty()).unwrap())
             .await
             .unwrap();
-        // No authenticators = open access
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_allow_all_authenticator_passes_unauthed_requests() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let app = make_auth_test_router(vec![Box::new(crate::AllowAllAuthenticator {
+            reason: "test",
+        })]);
+        // Request has no Authorization header at all - must still be allowed
+        // through the auth middleware to the (empty) /sockets handler.
+        let response = app
+            .oneshot(Request::get("/sockets").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 
@@ -1703,11 +1726,11 @@ mod sshauth_tests {
         let header = format!("Bearer {}", token.encode());
 
         // First use should succeed
-        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
             .expect("first use of nonce should pass");
 
         // Replay with the same nonce should fail
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb));
+        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb));
         assert!(result.is_err(), "replayed nonce should be rejected");
         assert!(
             result
@@ -1729,7 +1752,7 @@ mod sshauth_tests {
         let header = format!("Bearer {}", token.encode());
 
         // Without a nonce, the request should be rejected
-        let result = auth.check_request("GET", "/sockets", &header, None, None);
+        let result = auth.check_request("GET", "/sockets", Some(&header), None, None);
         assert!(result.is_err(), "request without nonce should be rejected");
         assert!(result.unwrap_err().to_string().contains("missing nonce"));
     }
@@ -1751,7 +1774,13 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb_verifier));
+        let result = auth.check_request(
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(cb_verifier),
+        );
         assert!(
             result.is_err(),
             "mismatched channel binding should be rejected (relay attack)"
@@ -1774,7 +1803,7 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
             .expect("matching channel binding should pass");
     }
 


### PR DESCRIPTION
Previously an empty authenticators list silently allowed all requests, making any future code path that fails to push an authenticator a latent open-access bug. The middleware now always iterates and fails closed on an empty list; --insecure and the mTLS-only path push an explicit AllowAllAuthenticator instead.