### PR TITLE
units: make varlink-httpd available early and fix vsock issue

### DIFF
--- a/data/varlink-httpd-vsock.socket
+++ b/data/varlink-httpd-vsock.socket
@@ -5,6 +5,11 @@
 [Unit]
 Description=Varlink HTTP Bridge (vsock)
 ConditionVirtualization=vm
+# Start early so the bridge is reachable for remote management while
+# systemd-firstboot.service may still be blocking.
+DefaultDependencies=no
+Before=sockets.target
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=vsock::1031

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -19,6 +19,12 @@ ExecStart=@bindir@/varlink-httpd
 Restart=on-failure
 RestartSec=5
 
+# Pass the FDs from both socket units in a single service start. Without
+# this, whichever socket triggers activation first wins the race; the
+# other socket's FD stays held by systemd and connections on that
+# transport never reach varlink-httpd.
+Sockets=varlink-httpd.socket varlink-httpd-vsock.socket
+
 # Hardening
 ProtectSystem=strict
 ProtectHome=yes

--- a/data/varlink-httpd.socket
+++ b/data/varlink-httpd.socket
@@ -4,6 +4,11 @@
 
 [Unit]
 Description=Varlink HTTP Bridge (TCP)
+# Start early so the bridge is reachable for remote management while
+# systemd-firstboot.service may still be blocking.
+DefaultDependencies=no
+Before=sockets.target
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=0.0.0.0:1031


### PR DESCRIPTION
This commit improves the varlink-httpd unit file. It makes varlink-httpd available early so that it runs even if e.g. firstboot is not completed.

It also fixes a bug in the service file where the sockets were not listed which resulted in a race that got us either vsock or tcp but not both.