### PR TITLE
sshauth: add retry support and Sk{Ed25519,EcdsaSha2NistP256}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,10 @@ openssl = "0.10.81"
 tokio-openssl = "0.6"
 indoc = "2.0.7"
 ssh-key = { version = "0.6", optional = true }
-sshauth = { version = "0.1", optional = true }
+# TODO: switch back to crates.io once SkEd25519 (hardware key) support is
+# merged and released (https://github.com/mvo5/sshauth/tree/add-support-for-SkEd25519)
+# (see https://github.com/oxidecomputer/sshauth/pull/8)
+sshauth = { git = "https://github.com/mvo5/sshauth.git", branch = "add-support-for-SkEd25519", optional = true }
 tempfile = { version = "3.27", optional = true }
 ssh-key-import = { path = "crates/ssh-key-import", optional = true }
 

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -18,16 +18,6 @@ use tokio_tungstenite::tungstenite::{self, Message};
 #[cfg(feature = "sshauth")]
 mod sshauth_client;
 
-#[cfg(feature = "sshauth")]
-use sshauth_client::maybe_add_auth_headers;
-#[cfg(not(feature = "sshauth"))]
-async fn maybe_add_auth_headers(
-    _request: &mut tungstenite::http::Request<()>,
-    _tls_channel_binding: Option<&str>,
-) -> Result<()> {
-    Ok(())
-}
-
 /// One object-safe type for all transport combinations
 /// (TCP/vsock, with/without TLS).
 trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send {}
@@ -196,7 +186,29 @@ fn resp_body_text(resp: &tungstenite::http::Response<Option<Vec<u8>>>) -> Option
         .map(|b| String::from_utf8_lossy(b).into_owned())
 }
 
+#[cfg(feature = "sshauth")]
 async fn connect_ws(url: &str) -> Result<Ws> {
+    sshauth_client::connect_with_ssh_retry(async |key| {
+        let (stream, mut request, tcb) = connect_transport(url).await?;
+        if let Some(key) = key {
+            sshauth_client::add_auth_headers(&mut request, key, tcb.as_deref()).await?;
+        }
+        ws_upgrade(request, stream, tcb.is_some()).await
+    })
+    .await
+}
+
+#[cfg(not(feature = "sshauth"))]
+async fn connect_ws(url: &str) -> Result<Ws> {
+    let (stream, request, tcb) = connect_transport(url).await?;
+    ws_upgrade(request, stream, tcb.is_some()).await
+}
+
+/// The TLS channel binding is returned so auth headers can be signed
+/// over it before the WebSocket upgrade.
+async fn connect_transport(
+    url: &str,
+) -> Result<(BoxedStream, tungstenite::http::Request<()>, Option<String>)> {
     use tungstenite::client::IntoClientRequest;
 
     let (stream, ws_url, tls_channel_binding) = if let Some(rest) = url.strip_prefix("vsock+tls://")
@@ -207,15 +219,22 @@ async fn connect_ws(url: &str) -> Result<Ws> {
     } else {
         connect_tcp(url).await?
     };
-    let is_tls = tls_channel_binding.is_some();
 
     // Use into_client_request() here as it auto-generates standard WS upgrade headers,
     // then we add our auth headers too
-    let mut request = ws_url
+    let request = ws_url
         .into_client_request()
         .context("building WS request")?;
-    maybe_add_auth_headers(&mut request, tls_channel_binding.as_deref()).await?;
+    Ok((stream, request, tls_channel_binding))
+}
 
+async fn ws_upgrade(
+    request: tungstenite::http::Request<()>,
+    stream: BoxedStream,
+    is_tls: bool,
+) -> Result<Ws> {
+    // anyhow keeps the tungstenite::Error downcastable through context():
+    // the SSH-retry logic detects a 401 via downcast_ref.
     let (ws, _) = tokio_tungstenite::client_async(request, stream)
         .await
         .map_err(|e| {
@@ -535,5 +554,39 @@ mod tests {
         assert!(parse_vsock_url("http://localhost").is_err());
         assert!(parse_vsock_url("vsock://notanumber:1031/path").is_err());
         assert!(parse_vsock_url("vsock://2:notaport/path").is_err());
+    }
+
+    #[cfg(feature = "sshauth")]
+    mod sshauth {
+        use super::*;
+
+        /// Wraps the handshake error the same way `ws_upgrade` does.
+        async fn handshake_error(response: &'static str) -> anyhow::Error {
+            // capacity must fit the unread client request or the handshake deadlocks
+            let (client, mut server) = tokio::io::duplex(64 * 1024);
+            server.write_all(response.as_bytes()).await.unwrap();
+            tokio_tungstenite::client_async("ws://localhost/", client)
+                .await
+                .map(|_| ())
+                .map_err(|e| anyhow::Error::new(e).context("WebSocket handshake failed"))
+                .expect_err("handshake should fail")
+        }
+
+        /// A handshake 401 must stay downcastable to `tungstenite::Error::Http`
+        /// through the anyhow context so the sshauth retry logic can detect it.
+        #[tokio::test]
+        async fn test_ws_handshake_401_is_detected_as_unauthorized() {
+            let err =
+                handshake_error("HTTP/1.1 401 Unauthorized\r\ncontent-length: 0\r\n\r\n").await;
+            assert!(sshauth_client::is_http_unauthorized(&err), "{err:#}");
+        }
+
+        #[tokio::test]
+        async fn test_ws_handshake_other_error_is_not_unauthorized() {
+            let err =
+                handshake_error("HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\n\r\n")
+                    .await;
+            assert!(!sshauth_client::is_http_unauthorized(&err), "{err:#}");
+        }
     }
 }

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -1,20 +1,62 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+use std::fmt;
+
 use anyhow::{Context, Result, bail};
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
 use varlink_http_bridge::SSHAUTH_MAGIC_PREFIX;
 
-struct Signer {
-    builder: sshauth::signer::TokenSignerBuilder,
-    algo: ssh_key::Algorithm,
-    fingerprint: ssh_key::Fingerprint,
-    comment: String,
-    source: String,
+/// An SSH key that can be used for authentication.
+pub(crate) enum SshKey {
+    /// A private key read from a file (`VARLINK_SSH_KEY`).
+    PrivateKey {
+        path: String,
+        key: Box<ssh_key::PrivateKey>,
+    },
+    /// A public key signed through the ssh-agent.  Used both when only
+    /// `SSH_AUTH_SOCK` is set and when `VARLINK_SSH_KEY` points to a
+    /// hardware token (sk-*) or a public-key-only file.
+    AgentKey {
+        auth_sock: String,
+        key: ssh_key::PublicKey,
+    },
 }
 
-pub(crate) async fn maybe_add_auth_headers(
+impl fmt::Display for SshKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SshKey::PrivateKey { path, key } => {
+                write!(
+                    f,
+                    "{} {} ({}) from {}",
+                    key.algorithm(),
+                    key.fingerprint(ssh_key::HashAlg::Sha256),
+                    key.comment(),
+                    path,
+                )
+            }
+            SshKey::AgentKey { auth_sock, key } => {
+                write!(
+                    f,
+                    "{} {} ({}) from agent {}",
+                    key.algorithm(),
+                    key.fingerprint(ssh_key::HashAlg::Sha256),
+                    key.comment(),
+                    auth_sock,
+                )
+            }
+        }
+    }
+}
+
+/// Add SSH auth headers to the request, signing with the given key.
+///
+/// A signing failure is returned as a [`SigningFailed`] error so the retry
+/// loop can skip the key and move on to the next one.
+pub(crate) async fn add_auth_headers(
     request: &mut tungstenite::http::Request<()>,
+    key: &SshKey,
     tls_channel_binding: Option<&str>,
 ) -> Result<()> {
     // to_string: ends the borrow of `request` before headers_mut() below
@@ -24,15 +66,13 @@ pub(crate) async fn maybe_add_auth_headers(
         .map_or(request.uri().path(), |pq| pq.as_str())
         .to_string();
 
-    let (bearer, nonce) = match build_auth_token("GET", &path_and_query, tls_channel_binding).await
-    {
-        Ok(Some((bearer, nonce))) => (bearer, nonce),
-        Ok(None) => return Ok(()),
-        Err(e) => return Err(e).context("auth token generation failed"),
-    };
+    let (auth_header, nonce) = sign_with_key(key, "GET", &path_and_query, tls_channel_binding)
+        .await
+        .context(SigningFailed)?;
+
     request.headers_mut().insert(
         "Authorization",
-        bearer.parse().context("invalid auth header value")?,
+        auth_header.parse().context("invalid auth header value")?,
     );
     request.headers_mut().insert(
         varlink_http_bridge::SSHAUTH_NONCE_HEADER,
@@ -41,53 +81,86 @@ pub(crate) async fn maybe_add_auth_headers(
     Ok(())
 }
 
-/// Build an SSH auth token for the given HTTP method and path.
+/// Try connecting with each available SSH key, retrying on 401.
 ///
-/// Returns `Ok(None)` when no SSH credentials are available.
-async fn build_auth_token(
-    method: &str,
-    path_and_query: &str,
-    tls_channel_binding: Option<&str>,
-) -> Result<Option<(String, String)>> {
-    let Some(mut signer) = build_signer().await? else {
-        return Ok(None);
-    };
-    debug!(
-        "SSH auth: using {} key {} ({}) from {}",
-        signer.algo, signer.fingerprint, signer.comment, signer.source,
-    );
-
-    let nonce = generate_nonce();
-
-    signer
-        .builder
-        .include_fingerprint(true)
-        .magic_prefix(SSHAUTH_MAGIC_PREFIX);
-    let token_signer = signer.builder.build()?;
-
-    let mut tb = token_signer.sign_for();
-    tb.action("method", method)
-        .action("path", path_and_query)
-        .action("nonce", &nonce)
-        .action(
-            "tls-channel-binding",
-            tls_channel_binding.unwrap_or_default(),
-        );
-
-    let token: sshauth::token::Token = tb.sign().await?;
-    Ok(Some((format!("Bearer {}", token.encode()), nonce)))
+/// Enumerates keys from the environment (`VARLINK_SSH_KEY` or `SSH_AUTH_SOCK`),
+/// then calls `connect` for each key. Skip keys that fail to sign or get 401.
+/// Any other error is returned immediately.
+///
+/// When no key was ever presented to the server (none available, or all of
+/// them failed to sign), `connect` is called once with `None`
+/// (unauthenticated) and the server decides whether to allow that.
+pub(crate) async fn connect_with_ssh_retry<T>(
+    connect: impl AsyncFnMut(Option<&SshKey>) -> Result<T>,
+) -> Result<T> {
+    let keys = list_ssh_keys().await?;
+    try_each_key(&keys, connect).await
 }
 
-/// Build a [`Signer`] from the available SSH credentials.
+/// Generic retry loop: try `connect` for each key.
+async fn try_each_key<K: fmt::Display, T>(
+    keys: &[K],
+    mut connect: impl AsyncFnMut(Option<&K>) -> Result<T>,
+) -> Result<T> {
+    let mut last_rejection = None;
+    let mut rejected = 0;
+    for key in keys {
+        match connect(Some(key)).await {
+            Ok(val) => return Ok(val),
+            Err(e) if is_http_unauthorized(&e) => {
+                debug!("SSH key {key} rejected by server (HTTP 401), trying next key");
+                last_rejection = Some(e);
+                rejected += 1;
+            }
+            Err(e) if is_signing_failure(&e) => {
+                warn!("skipping SSH key {key}: {e:#}");
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    match last_rejection {
+        // Rejected keys are logged only at debug level, so state the count to
+        // keep a multi-key failure from reading as a single-key one.
+        Some(e) if rejected > 1 => Err(e.context(format!(
+            "{rejected} SSH keys were rejected by the server (HTTP 401)"
+        ))),
+        // At least one key was presented and rejected: the server requires
+        // auth, so an unauthenticated attempt is pointless.
+        Some(e) => Err(e),
+        // No key was ever presented (none found, or all failed to sign):
+        // try unauthenticated and let the server decide.
+        None => connect(None).await,
+    }
+}
+
+/// Signing can fail for reasons that are not the key's fault (e.g. a
+/// hardware token that requires user presence and times out).
+#[derive(Debug, Clone, Copy)]
+struct SigningFailed;
+
+impl fmt::Display for SigningFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SSH token signing failed")
+    }
+}
+
+fn is_signing_failure(err: &anyhow::Error) -> bool {
+    err.is::<SigningFailed>()
+}
+
+pub(crate) fn is_http_unauthorized(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<tungstenite::Error>()
+        .is_some_and(|e| matches!(e, tungstenite::Error::Http(r) if r.status() == 401))
+}
+
+/// Return all available SSH keys for authentication.
 ///
-/// Reads `VARLINK_SSH_KEY` and `SSH_AUTH_SOCK` from the environment and
-/// tries, in order:
-/// 1. `VARLINK_SSH_KEY` with a private key on disk → sign directly.
-/// 2. `VARLINK_SSH_KEY` with only a public key → delegate to the ssh-agent.
-/// 3. `SSH_AUTH_SOCK` only → pick the first supported key from the agent.
-///
-/// Returns `Ok(None)` when neither variable is set.
-async fn build_signer() -> Result<Option<Signer>> {
+/// - `VARLINK_SSH_KEY` with a normal private key: a single `PrivateKey`.
+/// - `VARLINK_SSH_KEY` with a hardware token or public-key-only file: a
+///   single `AgentKey` (signed through `SSH_AUTH_SOCK`).
+/// - `SSH_AUTH_SOCK` only: every non-RSA key from the agent.
+/// - Neither: an empty vec (no auth).
+async fn list_ssh_keys() -> Result<Vec<SshKey>> {
     let key_path = std::env::var("VARLINK_SSH_KEY").ok();
     let auth_sock = std::env::var("SSH_AUTH_SOCK").ok();
 
@@ -96,30 +169,21 @@ async fn build_signer() -> Result<Option<Signer>> {
         if let Some(privkey) = read_private_key(&key_path)?
             && !requires_agent(&privkey.algorithm())
         {
-            let algo = privkey.algorithm();
-            let fingerprint = privkey.fingerprint(ssh_key::HashAlg::Sha256);
-            let comment = privkey.comment().to_string();
-            let builder = sshauth::TokenSigner::using_private_key(privkey)?;
-            return Ok(Some(Signer {
-                builder,
-                algo,
-                fingerprint,
-                comment,
-                source: key_path,
-            }));
+            return Ok(vec![SshKey::PrivateKey {
+                path: key_path,
+                key: Box::new(privkey),
+            }]);
         }
 
         // Otherwise delegate to the SSH agent: either the key is a
         // hardware token (sk-*) or only the .pub file exists on disk.
         let pubkey = read_public_key(&key_path)?;
-
-        // Delegate to the SSH agent for signing.
-        let auth_sock = auth_sock.as_deref().context(
+        let auth_sock = auth_sock.context(
             "VARLINK_SSH_KEY requires agent-based signing (hardware token \
              or public key only); set SSH_AUTH_SOCK",
         )?;
         let fp = pubkey.fingerprint(ssh_key::HashAlg::Sha256);
-        let agent_keys = sshauth::agent::list_keys(auth_sock)
+        let agent_keys = sshauth::agent::list_keys(&auth_sock)
             .await
             .context("listing ssh-agent keys")?;
         if !agent_keys
@@ -131,65 +195,83 @@ async fn build_signer() -> Result<Option<Signer>> {
                  add it with ssh-add or provide the private key"
             );
         }
-        let algo = pubkey.algorithm();
-        let comment = pubkey.comment().to_string();
-        let mut builder = sshauth::TokenSigner::using_authsock(auth_sock)?;
-        builder.key(pubkey);
-        return Ok(Some(Signer {
-            builder,
-            algo,
-            fingerprint: fp,
-            comment,
-            source: key_path,
-        }));
+        return Ok(vec![SshKey::AgentKey {
+            auth_sock,
+            key: pubkey,
+        }]);
     }
 
-    // SSH_AUTH_SOCK is set
     if let Some(auth_sock) = auth_sock {
-        let keys = sshauth::agent::list_keys(&auth_sock)
+        let all_keys = sshauth::agent::list_keys(&auth_sock)
             .await
             .context("listing ssh-agent keys")?;
-        let key = read_agent_key(keys)?;
-        let algo = key.algorithm();
-        let fingerprint = key.fingerprint(ssh_key::HashAlg::Sha256);
-        let comment = key.comment().to_string();
-        let mut builder = sshauth::TokenSigner::using_authsock(&auth_sock)?;
-        builder.key(key);
-        return Ok(Some(Signer {
-            builder,
-            algo,
-            fingerprint,
-            comment,
-            source: auth_sock,
-        }));
+
+        let mut keys = Vec::new();
+        for k in all_keys {
+            if matches!(k.algorithm(), ssh_key::Algorithm::Rsa { .. }) {
+                warn!(
+                    "skipping RSA key {} ({}): RSA signing is not supported, use Ed25519 or ECDSA",
+                    k.fingerprint(ssh_key::HashAlg::Sha256),
+                    k.comment(),
+                );
+            } else {
+                keys.push(SshKey::AgentKey {
+                    auth_sock: auth_sock.clone(),
+                    key: k,
+                });
+            }
+        }
+        return Ok(keys);
     }
 
-    // No VARLINK_SSH_KEY or SSH_AUTH_SOCK
-    Ok(None)
+    Ok(vec![])
+}
+
+/// Sign the request parameters (method, path, nonce, TLS channel binding)
+/// with the given key.  Returns the `Authorization` header value carrying
+/// the signed sshauth token, and the nonce.
+async fn sign_with_key(
+    key: &SshKey,
+    method: &str,
+    path_and_query: &str,
+    tls_channel_binding: Option<&str>,
+) -> Result<(String, String)> {
+    let nonce = generate_nonce();
+
+    let mut signer_builder = match key {
+        SshKey::PrivateKey { key, .. } => {
+            sshauth::TokenSigner::using_private_key(key.as_ref().clone())?
+        }
+        SshKey::AgentKey { auth_sock, key } => {
+            let mut sb = sshauth::TokenSigner::using_authsock(auth_sock)?;
+            sb.key(key.clone());
+            sb
+        }
+    };
+    debug!("SSH auth: using {key}");
+
+    signer_builder
+        .include_fingerprint(true)
+        .magic_prefix(SSHAUTH_MAGIC_PREFIX);
+    let signer = signer_builder.build()?;
+
+    let mut tb = signer.sign_for();
+    tb.action("method", method)
+        .action("path", path_and_query)
+        .action("nonce", &nonce)
+        .action(
+            "tls-channel-binding",
+            tls_channel_binding.unwrap_or_default(),
+        );
+    let token: sshauth::token::Token = tb.sign().await?;
+
+    Ok((format!("Bearer {}", token.encode()), nonce))
 }
 
 fn generate_nonce() -> String {
     let mut buf = [0u8; 16];
     openssl::rand::rand_bytes(&mut buf).expect("openssl PRNG failed");
     openssl::base64::encode_block(&buf)
-}
-
-/// Read the signing key from the agent.
-///
-/// Picks the first supported (non-RSA) key, warning about any RSA keys found.
-fn read_agent_key(keys: Vec<ssh_key::PublicKey>) -> Result<ssh_key::PublicKey> {
-    for k in &keys {
-        if ensure_supported_algorithm(&k.algorithm(), "ssh-agent key").is_err() {
-            warn!(
-                "skipping RSA key {} ({}): RSA signing is not supported, use Ed25519 or ECDSA",
-                k.fingerprint(ssh_key::HashAlg::Sha256),
-                k.comment(),
-            );
-        }
-    }
-    keys.into_iter()
-        .find(|k| ensure_supported_algorithm(&k.algorithm(), "ssh-agent key").is_ok())
-        .context("no supported key in ssh-agent")
 }
 
 /// Read a private key from `key_path`.
@@ -247,4 +329,205 @@ fn requires_agent(algo: &ssh_key::Algorithm) -> bool {
         algo,
         ssh_key::Algorithm::SkEcdsaSha2NistP256 | ssh_key::Algorithm::SkEd25519
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_http_error(status: u16) -> anyhow::Error {
+        let response = tungstenite::http::Response::builder()
+            .status(status)
+            .body(None)
+            .unwrap();
+        tungstenite::Error::Http(Box::new(response)).into()
+    }
+
+    fn make_signing_error() -> anyhow::Error {
+        anyhow::anyhow!("agent refused operation").context(SigningFailed)
+    }
+
+    #[test]
+    fn test_is_http_unauthorized_detects_401() {
+        assert!(is_http_unauthorized(&make_http_error(401)));
+    }
+
+    #[test]
+    fn test_is_http_unauthorized_ignores_other_status() {
+        assert!(!is_http_unauthorized(&make_http_error(403)));
+        assert!(!is_http_unauthorized(&make_http_error(500)));
+    }
+
+    #[test]
+    fn test_is_http_unauthorized_ignores_non_http_errors() {
+        assert!(!is_http_unauthorized(&anyhow::anyhow!(
+            "connection refused"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_retry_no_keys_connects_without_auth() {
+        let keys: Vec<String> = vec![];
+        let result = try_each_key(&keys, async |key| {
+            assert!(key.is_none());
+            Ok("connected")
+        })
+        .await;
+        assert_eq!(result.unwrap(), "connected");
+    }
+
+    #[tokio::test]
+    async fn test_retry_first_key_succeeds() {
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let attempts = std::cell::Cell::new(0);
+        let result = try_each_key(&keys, async |_key| {
+            attempts.set(attempts.get() + 1);
+            Ok("connected")
+        })
+        .await;
+        assert_eq!(result.unwrap(), "connected");
+        assert_eq!(attempts.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_retry_skips_401_tries_next_key() {
+        let keys = vec![
+            "key-a".to_string(),
+            "key-b".to_string(),
+            "key-c".to_string(),
+        ];
+        let attempts = std::cell::Cell::new(0);
+        let result = try_each_key(&keys, async |key| {
+            let n = attempts.get();
+            attempts.set(n + 1);
+            if n < 2 {
+                Err(make_http_error(401))
+            } else {
+                assert_eq!(key.unwrap(), "key-c");
+                Ok("connected")
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), "connected");
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_all_keys_rejected() {
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let result: Result<()> = try_each_key(&keys, async |_key| Err(make_http_error(401))).await;
+        let err = result.unwrap_err();
+        // Still downcasts to the underlying 401 after context is added.
+        assert!(is_http_unauthorized(&err));
+        // With multiple keys rejected the message must not imply a single key.
+        assert!(
+            format!("{err:#}").contains("2 SSH keys were rejected"),
+            "{err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_reject_count_excludes_signing_failures() {
+        // key-a fails to sign (skipped), key-b and key-c are rejected: the
+        // count must be 2 (rejections only), not 3 (total keys).
+        let keys = vec![
+            "key-a".to_string(),
+            "key-b".to_string(),
+            "key-c".to_string(),
+        ];
+        let attempts = std::cell::Cell::new(0);
+        let result: Result<()> = try_each_key(&keys, async |_key| {
+            let n = attempts.get();
+            attempts.set(n + 1);
+            if n == 0 {
+                Err(make_signing_error())
+            } else {
+                Err(make_http_error(401))
+            }
+        })
+        .await;
+        let err = result.unwrap_err();
+        assert!(is_http_unauthorized(&err));
+        assert!(
+            format!("{err:#}").contains("2 SSH keys were rejected"),
+            "{err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_single_key_rejected_keeps_bare_error() {
+        let keys = vec!["key-a".to_string()];
+        let result: Result<()> = try_each_key(&keys, async |_key| Err(make_http_error(401))).await;
+        let err = result.unwrap_err();
+        assert!(is_http_unauthorized(&err));
+        // Only one key: no misleading "all N keys" context added.
+        assert!(
+            !format!("{err:#}").contains("SSH keys were rejected"),
+            "{err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_signing_failure_skips_key() {
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let attempts = std::cell::Cell::new(0);
+        let result = try_each_key(&keys, async |key| {
+            let n = attempts.get();
+            attempts.set(n + 1);
+            if n == 0 {
+                Err(make_signing_error())
+            } else {
+                assert_eq!(key.unwrap(), "key-b");
+                Ok("connected")
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), "connected");
+        assert_eq!(attempts.get(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_retry_all_signing_failures_falls_back_unauthenticated() {
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let result = try_each_key(&keys, async |key| match key {
+            Some(_) => Err(make_signing_error()),
+            None => Ok("anonymous"),
+        })
+        .await;
+        assert_eq!(result.unwrap(), "anonymous");
+    }
+
+    #[tokio::test]
+    async fn test_retry_no_unauthenticated_fallback_after_rejection() {
+        // key-a fails to sign, key-b is rejected by the server: the server
+        // requires auth, so connect must not be called with None.
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let attempts = std::cell::Cell::new(0);
+        let result: Result<()> = try_each_key(&keys, async |key| {
+            assert!(key.is_some());
+            let n = attempts.get();
+            attempts.set(n + 1);
+            if n == 0 {
+                Err(make_signing_error())
+            } else {
+                Err(make_http_error(401))
+            }
+        })
+        .await;
+        assert!(is_http_unauthorized(&result.unwrap_err()));
+        assert_eq!(attempts.get(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_retry_non_auth_error_stops_immediately() {
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let attempts = std::cell::Cell::new(0);
+        let result: Result<()> = try_each_key(&keys, async |_key| {
+            attempts.set(attempts.get() + 1);
+            Err(anyhow::anyhow!("connection refused"))
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(attempts.get(), 1);
+    }
 }


### PR DESCRIPTION
This PR adds retry support for ssh keys (like ssh itself when there are multiple keys). It also moves to  the sshauth branch from https://github.com/oxidecomputer/sshauth/pull/8 to add support for HW ssh keys.

cc @pothos 