### PR TITLE
test: fix mTLS test failure

### DIFF
--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -872,7 +872,14 @@ async fn run_test_tls_server(
     varlink_sockets_path: &str,
     tls_acceptor: openssl::ssl::SslAcceptor,
 ) -> TestServer<std::net::SocketAddr> {
-    run_test_tls_server_with_auth(varlink_sockets_path, tls_acceptor, Vec::new()).await
+    // mirror the production mTLS-only path: the client is verified during
+    // the TLS handshake, no per-request HTTP authentication
+    run_test_tls_server_with_auth(
+        varlink_sockets_path,
+        tls_acceptor,
+        vec![Box::new(crate::AllowAllAuthenticator { reason: "test" })],
+    )
+    .await
 }
 
 async fn run_test_tls_server_with_auth(


### PR DESCRIPTION
In commit b05b680 we changed the server auth policy from fail-open to fail-closed. Before an empty authenticator list in auth_middleware meant "no auth required". Now that is no longer the case and for pure mTLS auth we need to push the crate::AllowAllAuthenticator explicitly. The is done automatically in varlink-httpd/main.rs for mTLS.

cc @katexochen 