### PR TITLE
varlink-httpd: replace deprecated Asn1StringRef::as_utf8 with to_string

### DIFF
--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -331,7 +331,7 @@ fn format_x509_subject(cert: &openssl::x509::X509Ref) -> String {
         .entries()
         .filter_map(|e| {
             let obj = e.object().nid().short_name().ok()?;
-            let val = e.data().as_utf8().ok()?;
+            let val = e.data().to_string().ok()?;
             Some(format!("{obj}={val}"))
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
openssl 0.10.81 deprecated Asn1StringRef::as_utf8() because it builds an OpensslString from a raw C string pointer and therefore truncates the value at the first interior NUL byte. The inherent to_string() method preserves the full contents and replaces invalid UTF-8 with U+FFFD.

Both return Result<_, ErrorStack>, so the .ok()? semantics in format_x509_subject() are unchanged. This only affects the client-cert subject logged on a new TLS connection.