### PR TITLE
Cargo: bump openssl to 0.10.81+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ signal-hook = "0.4"
 socket2 = "0.6"
 # using opeenssl here to keep size small, rusttls adds ~1.8MB binary size
 # and nativetls does not support mTLS
-openssl = "0.10"
+# 0.10.81: Asn1StringRef::to_string (format_x509_subject)
+openssl = "0.10.81"
 tokio-openssl = "0.6"
 indoc = "2.0.7"
 ssh-key = { version = "0.6", optional = true }


### PR DESCRIPTION
We use Asn1StringRef::to_string() and this needs 0.10.81+. This commit makes this explicit.