### PR TITLE
http: fail if the auth token creations fails

### DIFF
--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -35,10 +35,7 @@ pub(crate) fn maybe_add_auth_headers(
     let (bearer, nonce) = match build_auth_token("GET", path_and_query, tls_channel_binding) {
         Ok(Some((bearer, nonce))) => (bearer, nonce),
         Ok(None) => return Ok(()),
-        Err(e) => {
-            warn!("SSH auth token generation failed, proceeding without: {e:#}");
-            return Ok(());
-        }
+        Err(e) => return Err(e).context("auth token generation failed"),
     };
     request.headers_mut().insert(
         "Authorization",


### PR DESCRIPTION
The code used to just warn if building an auth token failed. This is bad because in eg. scripts it can lead to unexpected failures when the token building fails but the request is send anyway (and then rejected because it has no token). So be explicit and error if the token cannot be build right away.