### PR TITLE
mkosi: switch to ToolsTreeDistribution=fedora

### DIFF
--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -6,6 +6,7 @@ Format=none
 
 [Build]
 ToolsTree=default
+ToolsTreeDistribution=fedora
 BuildSources=..
 CacheDirectory=mkosi.cache
 WithNetwork=yes


### PR DESCRIPTION
The debian tree is currently broken:
```
Creating group 'systemd-network' with GID 996.
Creating user 'systemd-network' (systemd Network Management) with UID 996 and GID 996.
Setting access ACL "u::rwx,g::r-x,g:adm:r-x,m::r-x,o::r-x" on /var/log/journal failed: Invalid argument
dpkg: error processing package systemd (--configure):
 installed systemd package post-installation script subprocess returned error exit status 73
```
so lets switch to the fedora tools tree for now to unbreak our CI.