### PR TITLE
auth: add new jwt authentication support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ name = "varlinkctl-http"
 path = "src/bin/varlinkctl-http/main.rs"
 
 [features]
-default = ["sshauth"]
+default = ["sshauth", "jwtauth"]
 sshauth = ["dep:ssh-key", "dep:sshauth", "dep:tempfile", "dep:ssh-key-import"]
+jwtauth = ["dep:jsonwebtoken", "dep:ureq", "rustix/system"]
 # never enable directly: pulled in via the self dev-dependency so that
 # test-only constructors exist in test builds but not in release builds
 test-helpers = []
@@ -61,6 +62,8 @@ ssh-key = { version = "0.6", optional = true }
 sshauth = { git = "https://github.com/mvo5/sshauth.git", branch = "add-support-for-SkEd25519", optional = true }
 tempfile = { version = "3.27", optional = true }
 ssh-key-import = { path = "crates/ssh-key-import", optional = true }
+jsonwebtoken = { version = "9", optional = true }
+ureq = { version = "3", optional = true, default-features = false, features = ["native-tls"] }
 
 [dev-dependencies]
 varlink-http-bridge = { path = ".", features = ["test-helpers"] }

--- a/README.md
+++ b/README.md
@@ -405,6 +405,209 @@ This is recommended because for websocket requests only the initial
 "upgrade" request is signed with the ssh key, after the upgrade it is
 a plain WebSocket which relies on the underlying TLS for security.
 
+### JWT bearer authentication
+
+The bridge can also authenticate requests with a JSON Web Token (JWT)
+presented as `Authorization: Bearer <token>`. This is vendor-neutral:
+any OIDC-style issuer that signs tokens with **RS256** or **ES256** and
+publishes a JWKS works, including issuers you do not operate (GitHub
+Actions, Google, Keycloak, Auth0, ...).
+
+The node verifies the token's signature against the issuer's public keys
+(its JWKS), then checks `iss`, `aud` and `exp`. Because `aud` from a
+third-party IdP is often a shared value (not "this node"), real
+authorization comes from **claim requirements** on the node: one or more
+`--require-claim NAME=VALUE` rules that must all hold (see below).
+
+> **TLS is required in production.** A bearer token has no
+> proof-of-possession, so a captured token is replayable until it
+> expires; only transport TLS protects it in flight.
+
+#### Authorization: `--require-claim`
+
+Each `--require-claim NAME=VALUE` requires claim `NAME` to be present and
+to match `VALUE`. The rules compose:
+
+- distinct names are **ANDed**: every named claim must match;
+- repeating a name **ORs** its values: list it twice to allow either;
+- `VALUE` is an exact match or a `*` wildcard (e.g. `repo:myorg/*`); array
+  claims match if any element matches; `email_verified=true` works as-is.
+
+At least one rule is required. Without any, a valid token from the issuer would
+be accepted on `iss`/`aud`/`exp` alone, which is too weak for a third-party IdP
+(its `aud` is shared, not per-caller). So if no rule is configured, JWT auth is
+**not enabled**: the bridge logs a warning and leaves it off, while the other
+authenticators (SSH, mTLS) keep working.
+
+#### The issuer's public keys (JWKS)
+
+The node needs the issuer's public keys to verify signatures. By default it
+discovers them automatically: given an HTTPS `--issuer`, it fetches
+`<issuer>/.well-known/openid-configuration`, follows the `jwks_uri`, and caches
+the result. When a token arrives with an unknown key id the JWKS is re-fetched
+on demand (rate-limited), so issuer key rotation is handled without a restart.
+This is the right mode for third-party IdPs like Google and GitHub, which
+rotate their keys.
+
+To pin the keys instead (a self-run signer, an air-gapped node, or to avoid the
+outbound fetch), point `--issuer-jwks` at a local JWKS file; it overrides
+discovery and is hot-reloaded on change:
+
+```console
+$ curl -s https://<issuer>/.well-known/openid-configuration | jq -r .jwks_uri
+https://<issuer>/.well-known/jwks
+$ curl -s https://<issuer>/.well-known/jwks -o /etc/varlink-httpd/issuer-jwks.json
+```
+
+Server flags:
+
+```
+--issuer=URL                accepted 'iss' claim
+--audience=ID               accepted 'aud' claim (default: hostname)
+--issuer-jwks=PATH          pin a JWKS file (else fetched via OIDC discovery)
+--require-claim=NAME=VALUE  require claim NAME to match VALUE (repeatable)
+```
+
+Any of these can also come from a systemd credential instead of a flag.
+See "Auto-deploy via systemd credentials" below.
+
+#### Working example: a GitHub Actions org
+
+GitHub hands every workflow a short-lived OIDC token, so any CI job in
+your org can drive the bridge with no client certificate and no custom
+issuer. The token's GitHub claims (`repository_owner`, `repository`,
+`sub`, ...) drive authorization; see [GitHub's OIDC token
+reference](https://docs.github.com/en/actions/concepts/security/openid-connect#understanding-the-oidc-token)
+for the full set of claims and their formats.
+
+**Server**: trust the GitHub issuer and allow any repository in the
+`myorg` organisation:
+
+```console
+$ varlink-httpd \
+    --cert=server.pem --key=server-key.pem \
+    --issuer=https://token.actions.githubusercontent.com \
+    --audience=varlink-node-1 \
+    --require-claim=repository_owner=myorg
+```
+
+The node discovers GitHub's keys over HTTPS; no JWKS file is needed.
+
+`varlink-node-1` is a name you pick for this node: the server's `--audience` and
+the workflow's `&audience=` (below) must use the same string. For GitHub the
+audience is **not** an authorization boundary (the workflow chooses its own, so
+any repo could request `varlink-node-1`); it only marks a token as minted for
+this node. The `--require-claim` rules are what actually authorize, since GitHub,
+not the caller, sets `repository_owner` / `repository` / `sub`.
+
+Tighten the scope by adding or replacing `--require-claim` rules in the server
+command above (they compose):
+
+```console
+# a single repo
+--require-claim=repository=myorg/myrepo
+# only the main branch of that repo (sub encodes the ref/event)
+--require-claim="sub=repo:myorg/myrepo:ref:refs/heads/main"
+# either of two repos (OR), and only from the prod environment (AND)
+--require-claim=repository=myorg/a --require-claim=repository=myorg/b \
+    --require-claim=environment=prod
+```
+
+**Client**: in the workflow, request a token for that audience and pass
+it via `VARLINK_JWT` (requires `permissions: id-token: write`):
+
+```yaml
+jobs:
+  drive-node:
+    permissions:
+      id-token: write           # allow minting the OIDC token
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # fetch the OIDC token for our node's audience
+          TOKEN=$(curl -s \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=varlink-node-1" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            | jq -r .value)
+
+          VARLINK_JWT="$TOKEN" \
+          VARLINK_BRIDGE_URL=https://node-1:1031/ws/sockets/io.systemd.Hostname \
+            varlinkctl call exec:/usr/libexec/varlinkctl-http \
+            io.systemd.Hostname.Describe '{}'
+```
+
+#### Working example: a self-hosted Keycloak
+
+For real logins (SSO, multiple users, central revocation) without depending on a
+third party, run your own [Keycloak](https://www.keycloak.org/). Create a realm
+and a `varlink` client (public, with *Direct access grants*); Keycloak then
+serves discovery at `https://kc.example.com/realms/myrealm/.well-known/openid-configuration`,
+so the node fetches the keys itself (no `--issuer-jwks`):
+
+```console
+$ varlink-httpd ... \
+    --issuer=https://kc.example.com/realms/myrealm \
+    --audience=varlink \
+    --require-claim=sub=3f2a8c1e-...
+```
+
+`sub` is Keycloak's immutable per-user id (read it from the token, or the admin
+UI), so the rule survives a username rename; `preferred_username=me` is the
+readable alternative if you accept that a login name can change. Unlike the
+GitHub and Google cases, the id token's `aud` is your own client id, so
+`--audience=varlink` is a genuine boundary on top of the user claim. Fetch a
+token with the password grant in one request (`curl -d grant_type=password -d
+client_id=varlink -d scope="openid email" -d username=me -d password=... .../token`,
+read `.id_token`); the device and authorization-code flows work too.
+
+#### Other issuers (e.g. a personal Google account)
+
+Any OIDC issuer that signs with RS256/ES256 and publishes a discovery document
+works the same way: set `--issuer` and one or more `--require-claim` rules. A
+personal Google account is tempting because everyone already has one, but mind
+the audience. The easy path, `gcloud auth print-identity-token`, stamps `aud`
+with the *shared* Google Cloud SDK client id
+(`32555940559.apps.googleusercontent.com`) that every gcloud user also gets, so
+`aud` is worthless as a boundary and a single rule on the verified `email` (or
+`sub`) is the *only* thing authorizing the caller:
+
+```console
+$ varlink-httpd ... \
+    --issuer=https://accounts.google.com \
+    --audience=32555940559.apps.googleusercontent.com \
+    --require-claim=email=you@gmail.com \
+    --require-claim=email_verified=true
+```
+
+That works, but it leans the whole boundary on one claim, so do not loosen the
+`email`/`sub` rule. To get a real `aud` back, register your own Google OAuth
+client and fetch tokens with the device flow; by then you have done about as
+much setup as standing up a dedicated issuer like the Keycloak above.
+
+#### Auto-deploy via systemd credentials
+
+Every JWT setting can come from a systemd credential instead of a flag,
+so a node can be provisioned entirely from the credstore (see
+`systemd.exec(5)` and `systemd.system-credentials(7)`). JWT auth turns on
+as soon as an issuer is configured by either route.
+
+| Credential                         | Equivalent flag  |
+|------------------------------------|------------------|
+| `varlink-httpd.jwt.issuer`         | `--issuer`       |
+| `varlink-httpd.jwt.audience`       | `--audience`     |
+| `varlink-httpd.jwt.jwks`           | `--issuer-jwks` (optional; omit to use OIDC discovery) |
+| `varlink-httpd.jwt.require-claims` | `--require-claim` (one `NAME=VALUE` per line; `#` comments allowed) |
+
+For the GitHub org example above, provision the credstore instead of flags. With
+discovery there is no JWKS to ship, so the issuer is the only key-related entry:
+
+```console
+# /etc/credstore/ entries (or LoadCredential=/ImportCredential= in the unit)
+$ echo https://token.actions.githubusercontent.com \
+    > /etc/credstore/varlink-httpd.jwt.issuer
+$ echo varlink-node-1 > /etc/credstore/varlink-httpd.jwt.audience
+$ echo repository_owner=myorg > /etc/credstore/varlink-httpd.jwt.require-claims
+```
 
 ## vsock transport
 

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -52,5 +52,8 @@ ImportCredential=varlink-httpd.tls.trust:trust
 ImportCredential=ssh.authorized_keys.root
 ImportCredential=ssh.ephemeral-authorized_keys-all
 
+# JWT configuration (issuer, audience, jwks, require-claims)
+ImportCredential=varlink-httpd.jwt.*
+
 [Install]
 WantedBy=network.target

--- a/src/bin/varlink-httpd/auth_jwt.rs
+++ b/src/bin/varlink-httpd/auth_jwt.rs
@@ -1,0 +1,1299 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! JWT bearer-token authentication
+//!
+//! This is the JWT verify *core* plus the simplest auth mode, **Bearer**:
+//! the client presents only `Authorization: Bearer <JWT>`, the node verifies
+//! the JWS against a trusted JWKS and checks `iss` / `aud` / `exp`, then
+//! requires the configured claim rules (`--require-claim`) to match. There is
+//! no proof-of-possession; security rests on TLS, a short token lifetime and
+//! the claim rules.
+//!
+//! The proof-of-possession modes (RFC 9421 and `DPoP`) will be built
+//! later on this core.
+
+use anyhow::{Context, bail};
+use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, JwkSet};
+use jsonwebtoken::{Algorithm, DecodingKey};
+use log::{debug, info, warn};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant, SystemTime};
+use varlink_http_bridge::sysconf::{CredentialsLoader, find_config};
+
+use crate::{AuthRequest, Authenticator};
+
+/// Clock skew (seconds) tolerated when checking `exp` and `nbf`.
+const JWT_LEEWAY_SECS: u64 = 60;
+
+// To allow access via a JWT the user needs to set one or more rules of the
+// form `--require-claim=NAME=VALUE`. To validate those, our data structure
+// has three levels:
+//
+//   ClaimRules       all rules: every distinct NAME must match        (AND)
+//     AllowedValues    all VALUEs given for one NAME: any may match   (OR)
+//       ValueMatcher     a single VALUE: an exact string or a `*`-glob
+//
+// The `*`-glob engine is hand-rolled as it is very simple right now and it
+// avoids a dependency on a glob or fnmatch crate.
+
+/// All `--require-claim` rules: every distinct name must match (AND);
+/// a repeated name adds an alternative value (OR). E.g.
+/// `--require-claim=repository=myorg/foo --require-claim=env=staging --require-claim=env=test`
+/// translates to
+/// `repository=myorg/foo` AND (`env=staging` OR `env=test`)
+#[derive(Debug)]
+struct ClaimRules {
+    by_name: HashMap<String, AllowedValues>,
+}
+
+impl ClaimRules {
+    fn parse(rules: Vec<String>) -> anyhow::Result<Self> {
+        let mut by_name: HashMap<String, AllowedValues> = HashMap::new();
+        for rule in rules {
+            let (name, value) = rule.split_once('=').with_context(|| {
+                format!("invalid --require-claim '{rule}', expected NAME=VALUE")
+            })?;
+            by_name
+                .entry(name.to_string())
+                .or_default()
+                .push(ValueMatcher::new(value));
+        }
+        Ok(Self { by_name })
+    }
+
+    /// Verify every required claim is present and matches one of its allowed
+    /// values. On success returns the sorted names of the matched claims.
+    fn check(&self, claims: &Map<String, Value>) -> anyhow::Result<String> {
+        // Fail closed: with no rules a token would pass on signature alone.
+        if self.by_name.is_empty() {
+            bail!("JWT auth not configured: no claim rules to authorize against");
+        }
+        let mut matched = Vec::new();
+        for (name, allowed) in &self.by_name {
+            let Some(value) = claims.get(name) else {
+                bail!("required claim '{name}' is missing");
+            };
+            if !allowed.matches(value) {
+                debug!("JWT claim '{name}'={value} is not in the allowed set");
+                bail!("claim '{name}' is not in the allowed set");
+            }
+            debug!("JWT claim matched: {name}={value}");
+            matched.push(name.clone());
+        }
+        matched.sort_unstable();
+        Ok(matched.join(" "))
+    }
+
+    /// Sorted required-claim names (not their values), for logging.
+    fn names(&self) -> String {
+        let mut names: Vec<&str> = self.by_name.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names.join(" ")
+    }
+}
+
+/// One claim name allowed values (OR). Non-string claim values
+/// (e.g. number) are converted to strings before matching. This
+/// matches if any value for the claim name matches. E.g.
+/// `environment=staging` OR `environment=prod`
+#[derive(Debug, Default)]
+struct AllowedValues(Vec<ValueMatcher>);
+
+impl AllowedValues {
+    fn push(&mut self, matcher: ValueMatcher) {
+        self.0.push(matcher);
+    }
+
+    fn matches(&self, value: &Value) -> bool {
+        match value {
+            Value::String(s) => self.0.iter().any(|m| m.matches(s)),
+            Value::Bool(b) => self.0.iter().any(|m| m.matches(&b.to_string())),
+            Value::Number(n) => self.0.iter().any(|m| m.matches(&n.to_string())),
+            Value::Array(items) => items.iter().any(|v| self.matches(v)),
+            Value::Null | Value::Object(_) => false,
+        }
+    }
+}
+
+/// One allowed value: an exact string, or a `*`-wildcard pattern. E.g.
+/// `sub=repo:octo-org/octo-repo:*"`
+#[derive(Debug)]
+enum ValueMatcher {
+    Exact(String),
+    Glob(String),
+}
+
+impl ValueMatcher {
+    fn new(pattern: &str) -> Self {
+        if pattern.contains('*') {
+            Self::Glob(pattern.to_string())
+        } else {
+            Self::Exact(pattern.to_string())
+        }
+    }
+
+    fn matches(&self, value: &str) -> bool {
+        match self {
+            Self::Exact(s) => s == value,
+            Self::Glob(p) => glob_match_wildcard(p, value),
+        }
+    }
+}
+
+/// Match `value` against `pattern` with shell/fnmatch-style `*`, where `*`
+/// matches any run of characters (including none, and including separators).
+/// The whole string must match. Only `*` is special: `?` and `[...]` are
+/// literal, and matching is case-sensitive.
+// hand-rolled to avoid another dependency while we only need `*`.
+// TODO: pull in e.g. rust-lang/glob if we ever need full fnmatch.
+fn glob_match_wildcard(pattern: &str, value: &str) -> bool {
+    // The literal pieces between the '*'s. No '*' means an exact match.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return pattern == value;
+    }
+
+    // The piece before the first '*' must be a prefix of the value, the piece
+    // after the last '*' a suffix. Strip both; what's left in the middle must
+    // contain the remaining pieces in order.
+    let Some(after_prefix) = value.strip_prefix(parts[0]) else {
+        return false;
+    };
+    let Some(mut middle) = after_prefix.strip_suffix(parts[parts.len() - 1]) else {
+        return false;
+    };
+
+    for part in &parts[1..parts.len() - 1] {
+        match middle.find(part) {
+            Some(i) => middle = &middle[i + part.len()..],
+            None => return false,
+        }
+    }
+    true
+}
+
+// The JWKS fetching/handling is done via an abstract JwksSource that can either
+// be a file or URL source. Both will refresh automatically (the file on mtime
+// change and the URL periodically or if a keyId (kid) is missing).
+//
+// They have a keyring of all the JWKS keys used for verifying. Each key is
+// actually a key and the algorithm used so that an attacker cannot trick us
+// into using a key meant for RSA as a HMAC key. The hierarchy:
+//
+//   JwksSource      File(JwksFromFile) | Url(JwksFromUrl)
+//     JwksFromFile    mtime hot-reload      -> JwksKeyring
+//     JwksFromUrl     OIDC fetch + throttle -> JwksKeyring
+//       JwksKeyring     RwLock<KeyMap>: concurrent lookup + hot swap
+//         KeyMap          kid -> VerifyingKey
+//           VerifyingKey    one key + its pinned algorithm
+
+/// Where the trusted JWKS comes from: a local file (hot-reloaded) or a
+/// HTTP endpoint via OIDC discovery.
+enum JwksSource {
+    File(JwksFromFile),
+    Url(JwksFromUrl),
+}
+
+impl JwksSource {
+    fn lookup(&self, key_id: &str) -> anyhow::Result<VerifyingKey> {
+        match self {
+            JwksSource::File(file) => file.lookup(key_id),
+            JwksSource::Url(url) => url.lookup(key_id),
+        }
+    }
+
+    fn key_count(&self) -> usize {
+        let keyring = match self {
+            JwksSource::File(file) => &file.keys,
+            JwksSource::Url(url) => &url.keys,
+        };
+        keyring.len()
+    }
+}
+
+/// The trusted keyring. Reloads happen on demand inside a request, but
+/// requests run concurrently, so a lookup can race the reloading request's
+/// swap; the `RwLock` keeps concurrent lookups cheap and serializes only
+/// the swap.
+#[derive(Default)]
+struct JwksKeyring {
+    keys: RwLock<KeyMap>,
+}
+
+impl JwksKeyring {
+    /// Verifying key for `kid`, if currently present.
+    fn get(&self, key_id: &str) -> Option<VerifyingKey> {
+        self.keys.read().ok().and_then(|k| k.get(key_id))
+    }
+
+    /// Count of cached keys.
+    fn len(&self) -> usize {
+        self.keys.read().map_or(0, |k| k.len())
+    }
+
+    /// Log and install freshly-loaded keys.
+    fn swap(&self, keys: KeyMap, source: impl std::fmt::Display) {
+        info!(
+            "loaded {} JWKS {} from {source}",
+            keys.len(),
+            if keys.len() == 1 { "key" } else { "keys" }
+        );
+        if let Ok(mut guard) = self.keys.write() {
+            *guard = keys;
+        }
+    }
+}
+
+/// Retry gap for failed loads, so a persistently broken file is not
+/// re-parsed on every request.
+const JWKS_FILE_RETRY: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+struct ReloadState {
+    /// Only successful loads count (`None`: nothing loaded or file absent);
+    /// failures must stay retryable even when the mtime does not change.
+    loaded_mtime: Option<SystemTime>,
+    failed_at: Option<Instant>,
+}
+
+/// Trusted JWKS read from a local file, reloaded when the file's
+/// mtime changes. A read/parse error keeps the previous keys, a
+/// missing file drops them.
+struct JwksFromFile {
+    path: std::path::PathBuf,
+    keys: JwksKeyring,
+    state: Mutex<ReloadState>,
+}
+
+impl JwksFromFile {
+    fn new(path: std::path::PathBuf) -> Self {
+        let file = Self {
+            path,
+            keys: JwksKeyring::default(),
+            state: Mutex::new(ReloadState::default()),
+        };
+        file.maybe_reload(); // best-effort initial load; picked up later if absent
+        file
+    }
+
+    fn lookup(&self, key_id: &str) -> anyhow::Result<VerifyingKey> {
+        self.maybe_reload();
+        self.keys
+            .get(key_id)
+            .with_context(|| format!("no JWKS key for kid={key_id}"))
+    }
+
+    fn stat_mtime(path: &std::path::Path) -> std::io::Result<SystemTime> {
+        std::fs::metadata(path)?.modified()
+    }
+
+    /// Reload when the file's mtime changed. The lock is held across the
+    /// read so the swap is single-flight (cf. `JwksFromUrl::maybe_refresh`).
+    /// A failed load is retried (throttled) rather than parked until the
+    /// next mtime change: a non-atomic writer can finish inside the same
+    /// mtime tick, which would otherwise pin the previous keys forever.
+    fn maybe_reload(&self) {
+        let mtime = match Self::stat_mtime(&self.path) {
+            Ok(m) => Some(m),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            // Transient stat error: keep the cached keys rather than risk
+            // dropping them; retried on the next request.
+            Err(e) => {
+                warn!(
+                    "cannot stat {}: {e}, skipping JWKS reload",
+                    self.path.display()
+                );
+                return;
+            }
+        };
+        // poison-tolerant: a panic mid-reload must not panic every later request
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if mtime == state.loaded_mtime {
+            return;
+        }
+        if let Some(failed_at) = state.failed_at
+            && failed_at.elapsed() < JWKS_FILE_RETRY
+        {
+            return;
+        }
+        let parsed = match mtime {
+            None => Ok(KeyMap::default()), // missing file drops the keys
+            Some(_) => std::fs::read_to_string(&self.path)
+                .with_context(|| format!("failed to read JWKS from {}", self.path.display()))
+                .and_then(|data| KeyMap::parse(&data, self.path.display())),
+        };
+        match parsed {
+            Ok(keys) => {
+                state.loaded_mtime = mtime;
+                state.failed_at = None;
+                self.keys.swap(keys, self.path.display());
+            }
+            Err(e) => {
+                state.failed_at = Some(Instant::now());
+                warn!(
+                    "JWKS reload from {} failed: {e:#}; keeping previous keys",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}
+
+/// A JWKS fetched from the issuer over HTTP (typically via OIDC
+/// discovery), refreshed when older than `max_age` (so a key removal
+/// is eventually dropped) and on an unknown-`kid` miss (so a rotation
+/// is picked up at once). Both are throttled to `min_refetch`. A
+/// fetch failure keeps the previous keys. The triggering request
+/// blocks for the fetch (if this becomes a problem we can make it a
+/// background refresh).
+struct JwksFromUrl {
+    issuer: String,
+    keys: JwksKeyring,
+    /// Time of the last fetch *attempt* (success or failure); the lock is held
+    /// across the fetch (see `maybe_refresh`). Drives the `min_refetch` throttle.
+    last_attempt: Mutex<Option<Instant>>,
+    /// Time of the last *successful* fetch; drives the `max_age` staleness check.
+    /// Separate from `last_attempt` so a failed attempt doesn't look fresh.
+    last_success: Mutex<Option<Instant>>,
+    fetcher: JwksFetcher,
+    min_refetch: Duration,
+    max_age: Duration,
+}
+
+impl JwksFromUrl {
+    fn new(issuer: String, fetcher: JwksFetcher, min_refetch: Duration, max_age: Duration) -> Self {
+        let url = Self {
+            issuer,
+            keys: JwksKeyring::default(),
+            last_attempt: Mutex::new(None),
+            last_success: Mutex::new(None),
+            fetcher,
+            min_refetch,
+            max_age,
+        };
+        // Best-effort eager fetch: an unreachable/misconfigured issuer shows
+        // up in the startup logs instead of on the first request; a failure
+        // does not fail startup and is retried on the first miss.
+        url.maybe_refresh();
+        url
+    }
+
+    fn lookup(&self, key_id: &str) -> anyhow::Result<VerifyingKey> {
+        // Periodic refresh drops issuer-removed keys without needing a miss.
+        if self.is_stale() {
+            self.maybe_refresh();
+        }
+        if let Some(key) = self.keys.get(key_id) {
+            return Ok(key);
+        }
+        // Unknown kid: the issuer may have rotated. Refetch (throttled) and retry.
+        self.maybe_refresh();
+        self.keys
+            .get(key_id)
+            .with_context(|| format!("no JWKS key for kid={key_id}"))
+    }
+
+    // TODO: instead of this add a background fetcher that refreshes
+    // on JWKS_MAX_AGE. The current design has the big downside that
+    // if the bridge is used once per day each request will first
+    // refresh the JWKS which will result in a slow call.
+    /// Keys older than `max_age` (or never fetched) are due a refresh.
+    fn is_stale(&self) -> bool {
+        self.last_success
+            .lock()
+            .map_or(true, |t| t.is_none_or(|t| t.elapsed() >= self.max_age))
+    }
+
+    /// Refetch the JWKS, throttled to `min_refetch`; swap in the new keys on
+    /// success, keep the previous ones on failure.
+    ///
+    /// The `last_attempt` lock is held across the (network) fetch, so both
+    /// the fetch and any waiters block for up to the full fetch timeout;
+    /// `run_blocking_without_stalling_runtime` keeps that from starving the async runtime.
+    fn maybe_refresh(&self) {
+        run_blocking_without_stalling_runtime(|| self.refresh());
+    }
+
+    fn refresh(&self) {
+        // poison-tolerant: a panic mid-fetch must not panic every later request
+        let mut last_attempt = self
+            .last_attempt
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if last_attempt.is_some_and(|t| t.elapsed() < self.min_refetch) {
+            return; // throttled
+        }
+        let now = Instant::now();
+        *last_attempt = Some(now);
+        match (self.fetcher)() {
+            Ok(keys) => {
+                if let Ok(mut t) = self.last_success.lock() {
+                    *t = Some(now);
+                }
+                self.keys.swap(keys, &self.issuer);
+            }
+            Err(e) => warn!(
+                "JWKS fetch from {} failed: {e:#}; keeping previous keys",
+                self.issuer
+            ),
+        }
+    }
+}
+
+/// On a multi-thread runtime, `block_in_place` has tokio spin up a
+/// replacement worker, so a slow JWKS fetch stalls only its own request
+/// instead of the whole bridge; elsewhere (plain tests, current-thread
+/// runtimes, where it is unsupported) run directly.
+fn run_blocking_without_stalling_runtime<T>(f: impl FnOnce() -> T) -> T {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
+        _ => f(),
+    }
+}
+
+/// Minimum gap between on-demand JWKS refetches to avoid that we can
+/// get hammered by something that keeps requesting unknown keyIds.
+const JWKS_MIN_REFETCH: Duration = Duration::from_mins(1);
+
+/// How long before JWKS keys are re-fetched, so an issuer-side key
+/// removal (revocation) is eventually dropped.
+const JWKS_MAX_AGE: Duration = Duration::from_hours(8);
+
+/// Fetches a JWKS, returning the parsed keys. Boxed so the cache is agnostic
+/// to HTTP (and so tests can inject a fake without a server).
+type JwksFetcher = Box<dyn Fn() -> anyhow::Result<KeyMap> + Send + Sync>;
+
+#[derive(serde::Deserialize)]
+struct OidcDiscovery {
+    jwks_uri: String,
+}
+
+/// The bounded timeout keeps a stalled endpoint from hanging us. Redirect
+/// targets bypass our URL checks, so they must be constrained here:
+/// `https_only` makes ureq reject non-https redirects, and loopback dev mode
+/// (`https_only: false`) disables redirects entirely instead.
+fn build_jwks_agent(https_only: bool) -> ureq::Agent {
+    let tls = ureq::tls::TlsConfig::builder()
+        .provider(ureq::tls::TlsProvider::NativeTls)
+        .build();
+    let mut config = ureq::config::Config::builder()
+        .tls_config(tls)
+        .timeout_global(Some(std::time::Duration::from_secs(10)))
+        .https_only(https_only);
+    if !https_only {
+        config = config.max_redirects(0);
+    }
+    config.build().new_agent()
+}
+
+/// GET `url` with the body size-capped against a hostile or broken endpoint.
+fn get_capped(agent: &ureq::Agent, url: &str, what: &str) -> anyhow::Result<String> {
+    const BODY_LIMIT: u64 = 1024 * 1024;
+    agent
+        .get(url)
+        .call()
+        .with_context(|| format!("{what} request to {url} failed"))?
+        .body_mut()
+        .with_config()
+        .limit(BODY_LIMIT)
+        .read_to_string()
+        .with_context(|| format!("reading {what} from {url}"))
+}
+
+/// OIDC discovery: GET `<issuer>/.well-known/openid-configuration`, then GET its
+/// `jwks_uri`, and parse the result.
+fn fetch_jwks_via_discovery(issuer: &str, agent: &ureq::Agent) -> anyhow::Result<KeyMap> {
+    let discovery_url = format!(
+        "{}/.well-known/openid-configuration",
+        issuer.trim_end_matches('/')
+    );
+    let body = get_capped(agent, &discovery_url, "OIDC discovery")?;
+    let discovery: OidcDiscovery = serde_json::from_str(&body)
+        .with_context(|| format!("parsing OIDC discovery from {discovery_url}"))?;
+    require_secure_jwks_url(&discovery.jwks_uri)?;
+
+    let jwks = get_capped(agent, &discovery.jwks_uri, "JWKS")?;
+    KeyMap::parse(&jwks, &discovery.jwks_uri)
+}
+
+/// A parsed JWKS as a `kid -> VerifyingKey` map: the immutable batch produced by
+/// `parse` (or the fetcher) and swapped into a `JwksKeyring`.
+#[derive(Default)]
+struct KeyMap(HashMap<String, VerifyingKey>);
+
+impl KeyMap {
+    /// Parse a JWKS document (RFC 7517). `source` is used only for log/error
+    /// context. Unsupported (non RSA / EC P-256), malformed, or kid-less keys
+    /// are skipped rather than failing the whole set.
+    fn parse(data: &str, source: impl std::fmt::Display) -> anyhow::Result<Self> {
+        let set: JwkSet =
+            serde_json::from_str(data).with_context(|| format!("invalid JWKS from {source}"))?;
+
+        let mut keys = HashMap::new();
+        for jwk in &set.keys {
+            let alg = match &jwk.algorithm {
+                AlgorithmParameters::EllipticCurve(ec) if ec.curve == EllipticCurve::P256 => {
+                    Algorithm::ES256
+                }
+                AlgorithmParameters::RSA(_) => Algorithm::RS256,
+                other => {
+                    warn!(
+                        "ignoring unsupported JWK from {source} (only RSA/RS256 and EC P-256/ES256 \
+                         are supported): {other:?}"
+                    );
+                    continue;
+                }
+            };
+            let key = match DecodingKey::from_jwk(jwk) {
+                Ok(k) => k,
+                Err(e) => {
+                    warn!("ignoring malformed JWK from {source}: {e}");
+                    continue;
+                }
+            };
+
+            // kid is optional in rfc7517 but provided in practice by all
+            // relevant issuers. TODO: relax if a use-case appears.
+            let Some(key_id) = jwk.common.key_id.clone() else {
+                warn!("ignoring JWK without a key id (kid) from {source}");
+                continue;
+            };
+            debug!("JWKS key kid={key_id} alg={alg:?}");
+            keys.insert(key_id, VerifyingKey { key, alg });
+        }
+        Ok(Self(keys))
+    }
+
+    fn get(&self, key_id: &str) -> Option<VerifyingKey> {
+        self.0.get(key_id).cloned()
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// A verifying key from the JWKS plus the single algorithm it may be used with.
+/// Pinning the algorithm to the key type (never the attacker-chosen JWT header)
+/// prevents algorithm-confusion attacks.
+#[derive(Clone)]
+struct VerifyingKey {
+    key: DecodingKey,
+    alg: Algorithm,
+}
+
+pub(crate) struct JwtAuthenticator {
+    issuer: String,
+    audience: String,
+    jwks: JwksSource,
+    required_claims: ClaimRules,
+}
+
+impl std::fmt::Debug for JwtAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JwtAuthenticator")
+            .field("issuer", &self.issuer)
+            .field("audience", &self.audience)
+            // key_count is poison-tolerant, so Debug never panics.
+            .field("key_count", &self.jwks.key_count())
+            .field("required_claims", &self.required_claims)
+            .finish()
+    }
+}
+
+impl JwtAuthenticator {
+    fn with_source(
+        issuer: String,
+        audience: String,
+        jwks: JwksSource,
+        require_claims: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        if jwks.key_count() == 0 {
+            warn!(
+                "no usable JWKS keys loaded yet; JWT auth will reject requests until keys appear"
+            );
+        }
+        Ok(Self {
+            issuer,
+            audience,
+            jwks,
+            required_claims: ClaimRules::parse(require_claims)?,
+        })
+    }
+
+    pub(crate) fn key_count(&self) -> usize {
+        self.jwks.key_count()
+    }
+
+    pub(crate) fn required_claim_names(&self) -> String {
+        self.required_claims.names()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        issuer: String,
+        audience: String,
+        jwks_path: std::path::PathBuf,
+        require_claims: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let source = JwksSource::File(JwksFromFile::new(jwks_path));
+        Self::with_source(issuer, audience, source, require_claims)
+    }
+}
+
+impl Authenticator for JwtAuthenticator {
+    fn check_request(&self, request: &AuthRequest) -> anyhow::Result<()> {
+        let (method, path) = (request.method, request.path);
+        // Bearer mode only for now. TODO: add DPoP
+        let token = request.bearer_token()?;
+
+        let header = jsonwebtoken::decode_header(token).context("invalid JWT header")?;
+        // Note that "kid" is optional, but in practise it should be
+        // there for all relevant issuers.
+        let key_id = header.kid.context("token has no 'kid' header")?;
+        debug!(
+            "JWT auth: {method} {path} kid={key_id} header-alg={:?}",
+            header.alg
+        );
+
+        let verifying_key = self.jwks.lookup(&key_id).inspect_err(|e| {
+            debug!("JWT auth: no verifying key for {method} {path}: {e:#}");
+        })?;
+
+        let mut validation = jsonwebtoken::Validation::new(verifying_key.alg);
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&[&self.audience]);
+        // jsonwebtoken only checks iss/aud when the claim is present, so require
+        // them: a token from the trusted key that omits aud must not skip the
+        // per-node audience check.
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        // jsonwebtoken validates exp by default but not nbf; reject not-yet-valid tokens.
+        validation.validate_nbf = true;
+        validation.leeway = JWT_LEEWAY_SECS;
+
+        // Verify the JWS signature (against the pinned key + alg) and iss/aud/exp/nbf.
+        let data =
+            jsonwebtoken::decode::<Map<String, Value>>(token, &verifying_key.key, &validation)
+                // log the full chain at debug; the caller only surfaces the top message
+                .inspect_err(|e| {
+                    debug!("JWT verification failed for {method} {path} (kid={key_id}): {e:#}");
+                })
+                .context("JWT verification failed")?;
+        // Authenticated now; apply our authorization rules to the trusted claims.
+        let matched = self.required_claims.check(&data.claims)?;
+        info!("JWT auth OK: {method} {path} (matched claims: {matched})");
+        Ok(())
+    }
+}
+
+/// Well-known systemd credential names (see systemd.system-credentials(7)), so
+/// a node can be configured entirely from the credstore for auto-deployment.
+const JWKS_CREDENTIAL: &str = "varlink-httpd.jwt.jwks";
+const ISSUER_CREDENTIAL: &str = "varlink-httpd.jwt.issuer";
+const AUDIENCE_CREDENTIAL: &str = "varlink-httpd.jwt.audience";
+const REQUIRE_CLAIMS_CREDENTIAL: &str = "varlink-httpd.jwt.require-claims";
+
+/// Path under `/etc`, `/run` or `/usr/lib` for the shipped/admin JWKS file.
+const JWKS_CONFIG_REL: &str = "varlink-httpd/issuer-jwks.json";
+
+/// The scheme is parsed, not prefix-matched, so it is case-insensitive.
+fn is_http_url(s: &str) -> bool {
+    url_scheme(s).is_some_and(|scheme| {
+        scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+    })
+}
+
+fn url_scheme(url: &str) -> Option<String> {
+    url.parse::<ureq::http::Uri>()
+        .ok()?
+        .scheme_str()
+        .map(str::to_string)
+}
+
+/// True if `url`'s host is a loopback address (`localhost`, `127.0.0.0/8`, `::1`).
+fn is_loopback_url(url: &str) -> bool {
+    let Ok(uri) = url.parse::<ureq::http::Uri>() else {
+        return false;
+    };
+    let Some(host) = uri.host() else {
+        return false;
+    };
+    // Uri::host() returns IPv6 hosts bracketed ("[::1]"); IpAddr won't parse those.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Allow `https://` anywhere and plaintext `http://` only from loopback
+/// (local testing). An allowlist over parsed schemes: a denylist over string
+/// prefixes is case-trickable ("HTTP://") into a cleartext fetch.
+fn require_secure_jwks_url(url: &str) -> anyhow::Result<()> {
+    let scheme = url_scheme(url).unwrap_or_default();
+    if scheme.eq_ignore_ascii_case("https")
+        || (scheme.eq_ignore_ascii_case("http") && is_loopback_url(url))
+    {
+        return Ok(());
+    }
+    bail!(
+        "refusing to fetch JWKS from {url}: only https:// (or http:// from loopback) is supported"
+    );
+}
+
+/// Choose the JWKS source: an explicit/present file wins (the `jwks`
+/// argument, then an existing file in the `/etc` > `/run` >
+/// `/usr/lib` hierarchy); otherwise, if the issuer is an HTTP(S) URL,
+/// fetch it via OIDC discovery; otherwise watch the `/etc` config
+/// path so a later-installed file is still picked up.
+fn build_jwks_source(
+    jwks: Option<std::path::PathBuf>,
+    issuer: &str,
+    root: &std::path::Path,
+) -> anyhow::Result<JwksSource> {
+    if let Some(path) = jwks {
+        info!("JWT: using JWKS file {}", path.display());
+        return Ok(JwksSource::File(JwksFromFile::new(path)));
+    }
+    if let Some(path) = find_config(JWKS_CONFIG_REL, root) {
+        // An implicitly-found file is a local key pin and wins over discovery,
+        // but must not do so silently: it blocks issuer key rotation.
+        if is_http_url(issuer) {
+            warn!(
+                "JWT: found JWKS file {}; OIDC discovery from {issuer} is disabled and \
+                 issuer key rotation will not be picked up (remove the file, or pass \
+                 --issuer-jwks to make the pin explicit)",
+                path.display()
+            );
+        } else {
+            info!("JWT: using JWKS file {}", path.display());
+        }
+        return Ok(JwksSource::File(JwksFromFile::new(path)));
+    }
+    if is_http_url(issuer) {
+        require_secure_jwks_url(issuer)?;
+        info!("JWT: fetching JWKS via OIDC discovery from {issuer}");
+        let agent = build_jwks_agent(!is_loopback_url(issuer));
+        let issuer_owned = issuer.to_string();
+        let fetcher: JwksFetcher =
+            Box::new(move || fetch_jwks_via_discovery(&issuer_owned, &agent));
+        return Ok(JwksSource::Url(JwksFromUrl::new(
+            issuer.to_string(),
+            fetcher,
+            JWKS_MIN_REFETCH,
+            JWKS_MAX_AGE,
+        )));
+    }
+    // No file and the issuer isn't a URL: watch the /etc path for one to appear.
+    let path = root.join("etc").join(JWKS_CONFIG_REL);
+    Ok(JwksSource::File(JwksFromFile::new(path)))
+}
+
+/// Fresh P-256 keypair, shared by this module's and tests.rs's JWT tests.
+#[cfg(test)]
+pub(crate) fn generate_p256_keypair() -> openssl::pkey::PKey<openssl::pkey::Private> {
+    let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1).unwrap();
+    openssl::pkey::PKey::from_ec_key(openssl::ec::EcKey::generate(&group).unwrap()).unwrap()
+}
+
+/// Default audience when `--audience` is unset: this node's hostname. The only
+/// risk is a hostname collision across nodes, which silently widens scope.
+fn default_audience() -> anyhow::Result<String> {
+    let uname = rustix::system::uname();
+    Ok(uname
+        .nodename()
+        .to_str()
+        .context("hostname is not valid UTF-8")?
+        .to_string())
+}
+
+/// Build the JWT authenticator from CLI flags and/or systemd credentials.
+/// Returns `Ok(None)` when no issuer is configured (JWT auth not enabled).
+pub(crate) fn create_jwt_authenticator(
+    cli_options: crate::JwtCliOptions,
+    creds_dir: Option<&std::path::Path>,
+    root: &std::path::Path,
+) -> anyhow::Result<Option<JwtAuthenticator>> {
+    let creds = creds_dir.map(CredentialsLoader::from_dir);
+    let creds = creds.as_ref();
+
+    // A CLI option overrides (not extends) the matching credential.
+    let resolved = crate::JwtCliOptions {
+        issuer: cli_options
+            .issuer
+            .or_else(|| creds.and_then(|c| c.get_string(ISSUER_CREDENTIAL))),
+        audience: cli_options
+            .audience
+            .or_else(|| creds.and_then(|c| c.get_string(AUDIENCE_CREDENTIAL))),
+        issuer_jwks: cli_options
+            .issuer_jwks
+            .or_else(|| creds.and_then(|c| c.path(JWKS_CREDENTIAL))),
+        require_claims: if cli_options.require_claims.is_empty() {
+            creds
+                .map(|c| c.get_lines(REQUIRE_CLAIMS_CREDENTIAL))
+                .unwrap_or_default()
+        } else {
+            cli_options.require_claims
+        },
+    };
+
+    // exhaustive destructure, so a new option cannot be silently ignored
+    let (issuer, audience, issuer_jwks, require_claims) = match resolved {
+        crate::JwtCliOptions {
+            issuer: Some(issuer),
+            audience,
+            issuer_jwks,
+            require_claims,
+        } => (issuer, audience, issuer_jwks, require_claims),
+        // The above Some(issuer) ensures this match arm is taken if issuer
+        // is None.
+        cli_options_with_unset_issuer => {
+            if cli_options_with_unset_issuer.any_option_set() {
+                warn!(
+                    "JWT auth not enabled: no --issuer (nor the {ISSUER_CREDENTIAL} credential); \
+                     the other JWT settings (audience/jwks/require-claim) are ignored"
+                );
+            }
+            return Ok(None);
+        }
+    };
+    let audience = match audience {
+        Some(a) => a,
+        None => default_audience().context("--audience not set and hostname unavailable")?,
+    };
+    // With no rules from required claims any token that has signature
+    // + iss + aud + exp alone (aud is matched against --audience)
+    // would pass. Many third-party IdP are weak to identify the
+    // caller: `aud` is an app/org-wide value (Google: the OAuth
+    // client id; GitHub: an org URL the caller can even choose
+    // itself), so it proves almost nothing. So instead require a
+    // claim that the issuer sets and the caller cannot forge
+    // (repository/sub, verified email, ...). Unless we have
+    // require_claims turn off the jwt authenticator (at least for now
+    // until we have a better use-case)
+    if require_claims.is_empty() {
+        warn!(
+            "JWT auth not enabled: please add at least one --require-claim (or a \
+	     {REQUIRE_CLAIMS_CREDENTIAL} credential). Without this any token from {issuer} \
+	     with aud={audience} would be accepted which is unsafe."
+        );
+        return Ok(None);
+    }
+
+    let jwks = build_jwks_source(issuer_jwks, &issuer, root)?;
+    let auth =
+        JwtAuthenticator::with_source(issuer.clone(), audience.clone(), jwks, require_claims)?;
+    info!(
+        "Authenticator: adding JWT bearer (issuer={issuer}, audience={audience}, \
+         {count} {keys_word}, required-claims: {claims})",
+        count = auth.key_count(),
+        keys_word = if auth.key_count() == 1 { "key" } else { "keys" },
+        claims = auth.required_claim_names(),
+    );
+    Ok(Some(auth))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_glob_match_wildcard() {
+        assert!(glob_match_wildcard(
+            "repo:myorg/myrepo:*",
+            "repo:myorg/myrepo:ref:refs/heads/main"
+        ));
+        assert!(!glob_match_wildcard("repo:myorg/*", "repo:other/x"));
+        assert!(glob_match_wildcard("*", "anything"));
+        assert!(glob_match_wildcard("a*b*c", "a-b-c"));
+        assert!(glob_match_wildcard("a*c", "ac"));
+        assert!(!glob_match_wildcard("a*c", "ab"));
+        assert!(glob_match_wildcard("prefix*", "prefix"));
+        assert!(glob_match_wildcard("*suffix", "xxsuffix"));
+        assert!(!glob_match_wildcard("*suffix", "suffixx"));
+        assert!(glob_match_wildcard("noglob", "noglob"));
+        assert!(!glob_match_wildcard("noglob", "noglob2"));
+
+        // adjacent stars collapse to a single '*' (empty middle piece is a no-op)
+        assert!(glob_match_wildcard("a**b", "axxb"));
+        assert!(glob_match_wildcard("a**b", "ab"));
+
+        // only `*` is special: `?` and `[...]` are literal, matching is case-sensitive
+        assert!(glob_match_wildcard("a?c*", "a?cx"));
+        assert!(!glob_match_wildcard("a?c*", "abcx"));
+        assert!(glob_match_wildcard("a[x]*", "a[x]y"));
+        assert!(!glob_match_wildcard("ABC*", "abcx"));
+    }
+
+    #[test]
+    fn test_value_matcher_new() {
+        assert!(matches!(ValueMatcher::new("exact"), ValueMatcher::Exact(_)));
+        assert!(matches!(
+            ValueMatcher::new("has*star"),
+            ValueMatcher::Glob(_)
+        ));
+    }
+
+    #[test]
+    fn test_allowed_values_matches() {
+        let mut allowed = AllowedValues::default();
+        allowed.push(ValueMatcher::new("myorg"));
+        allowed.push(ValueMatcher::new("repo:*"));
+
+        assert!(allowed.matches(&json!("myorg")));
+        assert!(allowed.matches(&json!("repo:anything")));
+        assert!(!allowed.matches(&json!("other")));
+        // an array matches if any element does
+        assert!(allowed.matches(&json!(["x", "myorg"])));
+        assert!(!allowed.matches(&json!(["x", "y"])));
+        // null and objects never match
+        assert!(!allowed.matches(&json!(null)));
+        assert!(!allowed.matches(&json!({ "a": 1 })));
+
+        // bools and numbers are compared by their string form
+        let mut truthy = AllowedValues::default();
+        truthy.push(ValueMatcher::new("true"));
+        assert!(truthy.matches(&json!(true)));
+        assert!(!truthy.matches(&json!(false)));
+
+        let mut num = AllowedValues::default();
+        num.push(ValueMatcher::new("42"));
+        assert!(num.matches(&json!(42)));
+        assert!(!num.matches(&json!(43)));
+    }
+
+    #[test]
+    fn test_claim_rules_parse_rejects_malformed() {
+        let err = ClaimRules::parse(vec!["no-equals-sign".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("NAME=VALUE"), "got: {err}");
+    }
+
+    #[test]
+    fn test_claim_rules_check_and_or_and_summary() {
+        // distinct names AND; the repeated name ORs its values.
+        let rules = ClaimRules::parse(vec![
+            "repository=org/a".to_string(),
+            "repository=org/b".to_string(),
+            "environment=prod".to_string(),
+        ])
+        .unwrap();
+
+        let claims = |v: serde_json::Value| v.as_object().unwrap().clone();
+
+        // both names satisfied (repository via the second OR value); summary is
+        // the matched claim names, sorted, without the (possibly sensitive) values.
+        let summary = rules
+            .check(&claims(
+                json!({"repository": "org/b", "environment": "prod"}),
+            ))
+            .unwrap();
+        assert_eq!(summary, "environment repository");
+
+        // repository present but not an allowed value
+        assert!(
+            rules
+                .check(&claims(
+                    json!({"repository": "org/c", "environment": "prod"})
+                ))
+                .is_err()
+        );
+        // environment missing -> AND not satisfied
+        assert!(
+            rules
+                .check(&claims(json!({"repository": "org/a"})))
+                .is_err()
+        );
+    }
+
+    // A throwaway verifying key; URL-cache tests only check presence by kid, not
+    // the key material, so a fresh random EC key per call is fine.
+    fn fake_verifying_key() -> VerifyingKey {
+        let pem = generate_p256_keypair().public_key_to_pem().unwrap();
+        VerifyingKey {
+            key: DecodingKey::from_ec_pem(&pem).unwrap(),
+            alg: Algorithm::ES256,
+        }
+    }
+
+    fn keys_with(ids: &[&str]) -> KeyMap {
+        KeyMap(
+            ids.iter()
+                .map(|id| ((*id).to_string(), fake_verifying_key()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn test_url_jwks_initial_fetch_and_lookup() {
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(|| Ok(keys_with(&["k1"]))),
+            Duration::from_hours(1),
+            Duration::from_hours(1), // max_age (not exercised here)
+        );
+        assert!(url.lookup("k1").is_ok());
+        assert!(url.lookup("k2").is_err());
+    }
+
+    #[test]
+    fn test_url_jwks_refetches_on_unknown_kid() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let rotated = Arc::new(AtomicBool::new(false));
+        let r = rotated.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                if r.load(Ordering::SeqCst) {
+                    Ok(keys_with(&["k1", "k2"]))
+                } else {
+                    Ok(keys_with(&["k1"]))
+                }
+            }),
+            Duration::ZERO,          // no throttle: every miss refetches
+            Duration::from_hours(1), // max_age (not exercised here)
+        );
+        assert!(url.lookup("k1").is_ok());
+        assert!(url.lookup("k2").is_err()); // not rotated yet
+        rotated.store(true, Ordering::SeqCst);
+        assert!(url.lookup("k2").is_ok()); // unknown kid triggers a refetch
+    }
+
+    #[test]
+    fn test_url_jwks_throttles_refetch() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(keys_with(&["k1"]))
+            }),
+            Duration::from_hours(1), // long throttle
+            Duration::from_hours(1), // max_age (not exercised here)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "one initial fetch");
+        let _ = url.lookup("unknown");
+        let _ = url.lookup("unknown");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "refetch on unknown kid must be throttled"
+        );
+    }
+
+    #[test]
+    fn test_url_jwks_keeps_last_good_on_fetch_error() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let fail = Arc::new(AtomicBool::new(false));
+        let f = fail.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                if f.load(Ordering::SeqCst) {
+                    anyhow::bail!("issuer unreachable")
+                }
+                Ok(keys_with(&["k1"]))
+            }),
+            Duration::ZERO,
+            Duration::from_hours(1), // max_age (not exercised here)
+        );
+        assert!(url.lookup("k1").is_ok()); // good initial fetch
+        fail.store(true, Ordering::SeqCst);
+        assert!(url.lookup("k2").is_err()); // a miss now refetches and fails
+        assert!(
+            url.lookup("k1").is_ok(),
+            "previous keys must be retained on fetch failure"
+        );
+    }
+
+    #[test]
+    fn test_url_jwks_concurrent_unknown_kid_during_rotation() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let rotated = Arc::new(AtomicBool::new(false));
+        let r = rotated.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                // sleep so the two lookups below genuinely overlap on the fetch
+                std::thread::sleep(Duration::from_millis(50));
+                if r.load(Ordering::SeqCst) {
+                    Ok(keys_with(&["k1", "k2"]))
+                } else {
+                    Ok(keys_with(&["k1"]))
+                }
+            }),
+            Duration::ZERO,
+            Duration::from_hours(1), // max_age (not exercised here)
+        );
+        assert!(url.lookup("k1").is_ok());
+        rotated.store(true, Ordering::SeqCst);
+
+        // Two threads hit the new kid at once. Neither may get a false 401: the
+        // second must block on the in-flight fetch and then see the fresh keys.
+        let barrier = std::sync::Barrier::new(2);
+        let (a, b) = std::thread::scope(|s| {
+            let h = s.spawn(|| {
+                barrier.wait();
+                url.lookup("k2").is_ok()
+            });
+            barrier.wait();
+            (url.lookup("k2").is_ok(), h.join().unwrap())
+        });
+        assert!(a && b, "both concurrent lookups must see the rotated key");
+    }
+
+    #[test]
+    fn test_url_jwks_periodic_refresh_drops_removed_key() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        // max_age=0: every lookup is stale, so a periodic refresh runs.
+        let removed = Arc::new(AtomicBool::new(false));
+        let r = removed.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                if r.load(Ordering::SeqCst) {
+                    Ok(keys_with(&["k2"]))
+                } else {
+                    Ok(keys_with(&["k1"]))
+                }
+            }),
+            Duration::ZERO, // no throttle
+            Duration::ZERO, // always stale
+        );
+        assert!(url.lookup("k1").is_ok());
+        removed.store(true, Ordering::SeqCst);
+        // k1 is still a known kid: without periodic refresh it would stay cached.
+        assert!(url.lookup("k1").is_err());
+        assert!(url.lookup("k2").is_ok());
+    }
+
+    #[test]
+    fn test_url_jwks_no_refresh_within_max_age() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // min_refetch=0 isolates max_age: an extra fetch could only be staleness.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let url = JwksFromUrl::new(
+            "https://issuer.example".to_string(),
+            Box::new(move || {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(keys_with(&["k1"]))
+            }),
+            Duration::ZERO,
+            Duration::from_hours(1), // fresh for the whole test
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "one initial fetch");
+        let _ = url.lookup("k1");
+        let _ = url.lookup("k1");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "fresh keys must not trigger a refresh"
+        );
+    }
+
+    #[test]
+    fn test_empty_claim_rules_reject() {
+        // no rules must reject, not vacuously accept (fail closed)
+        let rules = ClaimRules::parse(vec![]).unwrap();
+        let err = rules
+            .check(&json!({"sub": "anyone"}).as_object().unwrap().clone())
+            .unwrap_err();
+        assert!(err.to_string().contains("no claim rules"), "got: {err}");
+    }
+
+    #[test]
+    fn test_require_secure_jwks_url() {
+        // https and loopback http are allowed
+        assert!(require_secure_jwks_url("https://issuer.example/jwks").is_ok());
+        assert!(require_secure_jwks_url("http://localhost:8080/jwks").is_ok());
+        assert!(require_secure_jwks_url("http://127.0.0.1/jwks").is_ok());
+        assert!(require_secure_jwks_url("http://[::1]:9000/jwks").is_ok());
+        // plaintext http to a routable host is rejected
+        assert!(require_secure_jwks_url("http://issuer.example/jwks").is_err());
+        assert!(require_secure_jwks_url("http://10.0.0.5/jwks").is_err());
+        // scheme matching must be case-insensitive: HTTP:// is still plaintext
+        assert!(require_secure_jwks_url("HTTP://issuer.example/jwks").is_err());
+        assert!(require_secure_jwks_url("HTTPS://issuer.example/jwks").is_ok());
+        // unknown schemes and non-URLs are rejected (allowlist, not denylist)
+        assert!(require_secure_jwks_url("ftp://issuer.example/jwks").is_err());
+        assert!(require_secure_jwks_url("issuer.example/jwks").is_err());
+        assert!(require_secure_jwks_url("").is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_run_blocking_without_stalling_runtime_on_multithread_runtime() {
+        // the block_in_place branch, from a worker
+        assert_eq!(run_blocking_without_stalling_runtime(|| 7), 7);
+        // and from the blocking pool, where a raw block_in_place could panic
+        let r = tokio::task::spawn_blocking(|| run_blocking_without_stalling_runtime(|| 7))
+            .await
+            .unwrap();
+        assert_eq!(r, 7);
+    }
+
+    #[tokio::test]
+    async fn test_run_blocking_without_stalling_runtime_on_current_thread_runtime() {
+        // block_in_place is unsupported here; must fall back to direct call
+        assert_eq!(run_blocking_without_stalling_runtime(|| 7), 7);
+    }
+
+    #[test]
+    fn test_run_blocking_without_stalling_runtime_outside_runtime() {
+        assert_eq!(run_blocking_without_stalling_runtime(|| 7), 7);
+    }
+
+    #[test]
+    fn test_jwks_file_fixed_within_same_mtime_tick_is_retried() {
+        // RFC 7517 A.1 example EC key; only needs to parse, not verify.
+        const VALID_JWKS: &str = r#"{"keys":[{"kty":"EC","crv":"P-256",
+            "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+            "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","kid":"1"}]}"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("jwks.json");
+        std::fs::write(&path, "{ mid-write garbage").unwrap();
+        let broken_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        let jwks = JwksFromFile::new(path.clone()); // initial load fails
+        assert_eq!(jwks.keys.len(), 0);
+
+        // The writer finishes within the same mtime tick.
+        std::fs::write(&path, VALID_JWKS).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(broken_mtime))
+            .unwrap();
+
+        jwks.maybe_reload();
+        assert_eq!(jwks.keys.len(), 0, "retry must be throttled");
+
+        // fast-forward past the throttle
+        jwks.state.lock().unwrap().failed_at = None;
+        jwks.maybe_reload();
+        assert_eq!(
+            jwks.keys.len(),
+            1,
+            "an unchanged mtime must not pin the broken state"
+        );
+    }
+}

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 // Reduced-feature builds leave some shared auth plumbing unused; the
-// default build still gets full dead-code checking.
-#![cfg_attr(not(feature = "sshauth"), allow(dead_code))]
+// default all-features build still gets full dead-code checking.
+#![cfg_attr(not(all(feature = "sshauth", feature = "jwtauth")), allow(dead_code))]
 
 use anyhow::{Context, bail};
 use async_stream::stream;
@@ -34,6 +34,8 @@ use tokio_vsock::VsockListener;
 use varlink_http_bridge::TlsChannelBinding;
 use zlink::varlink_service::Proxy;
 
+#[cfg(feature = "jwtauth")]
+mod auth_jwt;
 #[cfg(feature = "sshauth")]
 mod auth_ssh;
 #[cfg(feature = "sshauth")]
@@ -42,8 +44,11 @@ mod ws_framing;
 
 use ws_framing::VarlinkFramer;
 
+#[cfg(feature = "jwtauth")]
+use auth_jwt::create_jwt_authenticator;
 #[cfg(feature = "sshauth")]
 use auth_ssh::create_ssh_authenticator;
+
 #[derive(Debug)]
 struct AppError {
     status: StatusCode,
@@ -1052,7 +1057,9 @@ async fn start_server(
 
 #[derive(Debug)]
 enum Command {
-    Bridge(BridgeCli),
+    // Boxed: BridgeCli is much larger than the other variants, so storing it
+    // inline would bloat every Command to its size (clippy::large_enum_variant).
+    Bridge(Box<BridgeCli>),
     #[cfg(feature = "sshauth")]
     ImportSsh(import_ssh::ImportSsh),
 }
@@ -1132,6 +1139,23 @@ impl std::str::FromStr for BindAddr {
     }
 }
 
+#[derive(Debug, Default)]
+struct JwtCliOptions {
+    issuer: Option<String>,
+    audience: Option<String>,
+    issuer_jwks: Option<std::path::PathBuf>,
+    require_claims: Vec<String>,
+}
+
+impl JwtCliOptions {
+    fn any_option_set(&self) -> bool {
+        self.issuer.is_some()
+            || self.audience.is_some()
+            || self.issuer_jwks.is_some()
+            || !self.require_claims.is_empty()
+    }
+}
+
 #[derive(Debug)]
 struct BridgeCli {
     binds: Vec<BindAddr>,
@@ -1140,6 +1164,7 @@ struct BridgeCli {
     key: Option<String>,
     trust: Option<String>,
     authorized_keys: Option<String>,
+    jwt: JwtCliOptions,
     insecure: bool,
 }
 
@@ -1166,6 +1191,11 @@ fn print_help() {
           --key=PATH                        TLS private key PEM file
           --trust=PATH                      CA certificate PEM for client verification (mTLS)
           --authorized-keys=PATH            authorized SSH public keys file
+          --issuer=URL                      JWT issuer (accepted 'iss'); enables JWT bearer auth
+          --audience=ID                     accepted JWT 'aud' (default: hostname)
+          --issuer-jwks=PATH                issuer JWKS file (RS256/ES256 public keys)
+          --require-claim=NAME=VALUE        require claim NAME to match VALUE ('*' globs;
+                                            repeat for OR; distinct names AND), repeatable
           --insecure                        run without any authentication (DANGEROUS)
           --help                            display this help and exit
     "}
@@ -1197,6 +1227,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     let mut key = None;
     let mut trust = None;
     let mut authorized_keys = None;
+    let mut jwt = JwtCliOptions::default();
     let mut insecure = false;
     let mut got_positional = false;
 
@@ -1208,6 +1239,10 @@ fn parse_cli() -> anyhow::Result<Command> {
             Long("key") => key = Some(parser.value()?.parse()?),
             Long("trust") => trust = Some(parser.value()?.parse()?),
             Long("authorized-keys") => authorized_keys = Some(parser.value()?.parse()?),
+            Long("issuer") => jwt.issuer = Some(parser.value()?.parse()?),
+            Long("audience") => jwt.audience = Some(parser.value()?.parse()?),
+            Long("issuer-jwks") => jwt.issuer_jwks = Some(parser.value()?.into()),
+            Long("require-claim") => jwt.require_claims.push(parser.value()?.parse()?),
             Long("insecure") => insecure = true,
             Long("help") => {
                 print_help();
@@ -1237,15 +1272,16 @@ fn parse_cli() -> anyhow::Result<Command> {
         .map(|s| s.parse())
         .collect::<Result<_, _>>()?;
 
-    Ok(Command::Bridge(BridgeCli {
+    Ok(Command::Bridge(Box::new(BridgeCli {
         binds,
         varlink_sockets_path,
         cert,
         key,
         trust,
         authorized_keys,
+        jwt,
         insecure,
-    }))
+    })))
 }
 
 #[cfg(feature = "sshauth")]
@@ -1298,6 +1334,13 @@ async fn main() -> anyhow::Result<()> {
         bail!("--authorized-keys= requires building with the 'sshauth' feature");
     }
 
+    #[cfg(not(feature = "jwtauth"))]
+    if cli.jwt.any_option_set() {
+        bail!(
+            "--issuer/--audience/--issuer-jwks/--require-claim require building with the 'jwtauth' feature"
+        );
+    }
+
     let mut authenticators: Vec<Box<dyn Authenticator>> = Vec::new();
 
     #[cfg(feature = "sshauth")]
@@ -1308,6 +1351,13 @@ async fn main() -> anyhow::Result<()> {
             std::path::Path::new("/"),
         )?;
         authenticators.push(Box::new(ssh_auth));
+    }
+
+    #[cfg(feature = "jwtauth")]
+    if let Some(jwt_auth) =
+        create_jwt_authenticator(cli.jwt, creds_dir.as_deref(), std::path::Path::new("/"))?
+    {
+        authenticators.push(Box::new(jwt_auth));
     }
 
     if cli.insecure {

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1990,3 +1990,951 @@ mod sshauth_tests {
         assert_hostname_reply(&output);
     }
 } // mod sshauth_tests
+
+// --- JWT bearer auth tests ---
+
+#[cfg(feature = "jwtauth")]
+mod jwtauth_tests {
+    use super::*;
+    use crate::auth_jwt::{JwtAuthenticator, create_jwt_authenticator};
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use openssl::pkey::PKey;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const TEST_ISSUER: &str = "https://issuer.example";
+    const TEST_AUDIENCE: &str = "node-1";
+
+    fn now_secs() -> i64 {
+        i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap()
+    }
+
+    /// base64url without padding, per RFC 7515/7518 (JWK members).
+    fn b64url(bytes: &[u8]) -> String {
+        openssl::base64::encode_block(bytes)
+            .trim_end_matches('=')
+            .replace('+', "-")
+            .replace('/', "_")
+    }
+
+    /// Left-pad a big-endian integer to `len` bytes (JWK coordinates are
+    /// fixed-width; `BigNum::to_vec` drops leading zero bytes).
+    fn pad_be(bytes: &[u8], len: usize) -> Vec<u8> {
+        let mut out = vec![0u8; len.saturating_sub(bytes.len())];
+        out.extend_from_slice(bytes);
+        out
+    }
+
+    /// A test JWT issuer: a freshly generated keypair plus the matching JWKS.
+    struct TestIssuer {
+        priv_pem: Vec<u8>,
+        alg: Algorithm,
+        kid: String,
+    }
+
+    impl TestIssuer {
+        fn es256() -> Self {
+            let pkey = crate::auth_jwt::generate_p256_keypair();
+            Self {
+                priv_pem: pkey.private_key_to_pem_pkcs8().unwrap(),
+                alg: Algorithm::ES256,
+                kid: "test-ec".to_string(),
+            }
+        }
+
+        fn rs256() -> Self {
+            let rsa = openssl::rsa::Rsa::generate(2048).unwrap();
+            let pkey = PKey::from_rsa(rsa).unwrap();
+            Self {
+                priv_pem: pkey.private_key_to_pem_pkcs8().unwrap(),
+                alg: Algorithm::RS256,
+                kid: "test-rsa".to_string(),
+            }
+        }
+
+        /// The public half of this issuer's key as a single JWK.
+        fn jwk(&self) -> Value {
+            let pkey = PKey::private_key_from_pem(&self.priv_pem).unwrap();
+            match self.alg {
+                Algorithm::ES256 => {
+                    use openssl::bn::{BigNum, BigNumContext};
+                    let ec = pkey.ec_key().unwrap();
+                    let mut ctx = BigNumContext::new().unwrap();
+                    let (mut x, mut y) = (BigNum::new().unwrap(), BigNum::new().unwrap());
+                    ec.public_key()
+                        .affine_coordinates(ec.group(), &mut x, &mut y, &mut ctx)
+                        .unwrap();
+                    json!({
+                        "kty": "EC", "crv": "P-256", "alg": "ES256", "use": "sig",
+                        "kid": self.kid,
+                        "x": b64url(&pad_be(&x.to_vec(), 32)),
+                        "y": b64url(&pad_be(&y.to_vec(), 32)),
+                    })
+                }
+                Algorithm::RS256 => {
+                    let rsa = pkey.rsa().unwrap();
+                    json!({
+                        "kty": "RSA", "alg": "RS256", "use": "sig",
+                        "kid": self.kid,
+                        "n": b64url(&rsa.n().to_vec()),
+                        "e": b64url(&rsa.e().to_vec()),
+                    })
+                }
+                other => panic!("unsupported test alg {other:?}"),
+            }
+        }
+
+        /// Write this issuer's JWKS to a fresh temp file and return both the
+        /// tempdir (keep it alive) and the path.
+        fn write_jwks(&self) -> (tempfile::TempDir, std::path::PathBuf) {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("jwks.json");
+            let jwks = json!({ "keys": [self.jwk()] });
+            std::fs::write(&path, serde_json::to_vec(&jwks).unwrap()).unwrap();
+            (dir, path)
+        }
+
+        fn encoding_key(&self) -> EncodingKey {
+            match self.alg {
+                Algorithm::ES256 => EncodingKey::from_ec_pem(&self.priv_pem).unwrap(),
+                Algorithm::RS256 => EncodingKey::from_rsa_pem(&self.priv_pem).unwrap(),
+                other => panic!("unsupported test alg {other:?}"),
+            }
+        }
+
+        fn mint(&self, claims: &Value) -> String {
+            let mut header = Header::new(self.alg);
+            header.kid = Some(self.kid.clone());
+            encode(&header, claims, &self.encoding_key()).unwrap()
+        }
+    }
+
+    /// Standard, valid set of claims (iss/aud match the server, not expired).
+    fn valid_claims(sub: &str) -> Value {
+        json!({
+            "iss": TEST_ISSUER,
+            "aud": TEST_AUDIENCE,
+            "sub": sub,
+            "exp": now_secs() + 300,
+            "iat": now_secs(),
+        })
+    }
+
+    /// `JwtAuthenticator` backed by `issuer`'s JWKS, with the given
+    /// `--require-claim` rules (e.g. `["sub=alice"]`).
+    fn auth_with_claims(
+        issuer: &TestIssuer,
+        rules: &[&str],
+    ) -> (tempfile::TempDir, JwtAuthenticator) {
+        let (dir, jwks_path) = issuer.write_jwks();
+        let auth = JwtAuthenticator::new_for_test(
+            TEST_ISSUER.to_string(),
+            TEST_AUDIENCE.to_string(),
+            jwks_path,
+            rules.iter().map(|s| (*s).to_string()).collect(),
+        )
+        .unwrap();
+        (dir, auth)
+    }
+
+    /// `JwtAuthenticator` requiring `sub == "alice"`, backed by `issuer`'s JWKS.
+    fn auth_with_allowlist(issuer: &TestIssuer) -> (tempfile::TempDir, JwtAuthenticator) {
+        auth_with_claims(issuer, &["sub=alice"])
+    }
+
+    fn bearer(token: &str) -> String {
+        format!("Bearer {token}")
+    }
+
+    #[test]
+    fn test_jwt_accepts_valid_es256_allowlisted_sub() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let token = issuer.mint(&valid_claims("alice"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("valid token for allowlisted sub should pass");
+    }
+
+    #[test]
+    fn test_jwt_rejects_sub_not_in_allowlist() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let token = issuer.mint(&valid_claims("mallory"));
+        let err =
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("not in the allowed set"),
+            "expected allowlist rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jwt_accepts_rs256() {
+        let issuer = TestIssuer::rs256();
+        // sub=anyone is satisfied by the token, so this exercises RS256 verification.
+        let (_dir, auth) = auth_with_claims(&issuer, &["sub=anyone"]);
+        let token = issuer.mint(&valid_claims("anyone"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("valid RS256 token should pass");
+    }
+
+    #[test]
+    fn test_jwt_accepts_matching_custom_claim() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_claims(&issuer, &["hd=example.com"]);
+        let mut claims = valid_claims("anyone");
+        claims["hd"] = json!("example.com");
+        let token = issuer.mint(&claims);
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("token with the required claim value should pass");
+    }
+
+    #[test]
+    fn test_jwt_glob_claim_match() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_claims(&issuer, &["sub=repo:myorg/myrepo:*"]);
+
+        let mut ok = valid_claims("x");
+        ok["sub"] = json!("repo:myorg/myrepo:ref:refs/heads/main");
+        let token = issuer.mint(&ok);
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("glob should match any ref under the repo");
+
+        let mut bad = valid_claims("x");
+        bad["sub"] = json!("repo:otherorg/repo:ref:refs/heads/main");
+        let token = issuer.mint(&bad);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "glob is anchored: a different repo must not match"
+        );
+    }
+
+    #[test]
+    fn test_jwt_distinct_claims_are_anded() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) =
+            auth_with_claims(&issuer, &["repository=myorg/myrepo", "environment=prod"]);
+
+        let mut claims = valid_claims("x");
+        claims["repository"] = json!("myorg/myrepo");
+        claims["environment"] = json!("prod");
+        let token = issuer.mint(&claims);
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("both required claims present and matching");
+
+        let mut claims = valid_claims("x");
+        claims["repository"] = json!("myorg/myrepo");
+        claims["environment"] = json!("staging");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "all distinct claims must match (AND)"
+        );
+
+        let mut claims = valid_claims("x");
+        claims["repository"] = json!("myorg/myrepo");
+        let token = issuer.mint(&claims);
+        let err =
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).unwrap_err();
+        assert!(err.to_string().contains("missing"), "got: {err}");
+    }
+
+    #[test]
+    fn test_jwt_repeated_claim_is_ored() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_claims(&issuer, &["repository=myorg/a", "repository=myorg/b"]);
+        for repo in ["myorg/a", "myorg/b"] {
+            let mut claims = valid_claims("x");
+            claims["repository"] = json!(repo);
+            let token = issuer.mint(&claims);
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+                .unwrap_or_else(|e| panic!("repository {repo} should be allowed: {e}"));
+        }
+        let mut claims = valid_claims("x");
+        claims["repository"] = json!("myorg/c");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "a value not listed must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_jwt_array_claim_matches_any_element() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_claims(&issuer, &["groups=admins"]);
+        let mut claims = valid_claims("x");
+        claims["groups"] = json!(["users", "admins"]);
+        let token = issuer.mint(&claims);
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("array claim should match if any element matches");
+    }
+
+    #[test]
+    fn test_jwt_configured_entirely_from_credentials() {
+        let issuer = TestIssuer::es256();
+        let creds = tempfile::tempdir().unwrap();
+        let jwks = json!({ "keys": [issuer.jwk()] });
+        std::fs::write(
+            creds.path().join("varlink-httpd.jwt.jwks"),
+            serde_json::to_vec(&jwks).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(creds.path().join("varlink-httpd.jwt.issuer"), TEST_ISSUER).unwrap();
+        std::fs::write(
+            creds.path().join("varlink-httpd.jwt.audience"),
+            TEST_AUDIENCE,
+        )
+        .unwrap();
+        std::fs::write(
+            creds.path().join("varlink-httpd.jwt.require-claims"),
+            "sub=alice\n# a comment line\n",
+        )
+        .unwrap();
+
+        // Empty root so the /etc path is absent; everything resolves from creds.
+        let root = tempfile::tempdir().unwrap();
+        let auth =
+            create_jwt_authenticator(JwtCliOptions::default(), Some(creds.path()), root.path())
+                .unwrap()
+                .expect("issuer credential should enable JWT auth");
+
+        let token = issuer.mint(&valid_claims("alice"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("credential-configured node should accept a valid token");
+
+        let token = issuer.mint(&valid_claims("mallory"));
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "require-claims credential should still be enforced"
+        );
+    }
+
+    #[test]
+    fn test_jwt_cli_require_claims_override_credential() {
+        let issuer = TestIssuer::es256();
+        let creds = tempfile::tempdir().unwrap();
+        std::fs::write(
+            creds.path().join("varlink-httpd.jwt.jwks"),
+            serde_json::to_vec(&json!({ "keys": [issuer.jwk()] })).unwrap(),
+        )
+        .unwrap();
+        // Credential requires sub=alice; the CLI flag must replace it, not merge.
+        std::fs::write(
+            creds.path().join("varlink-httpd.jwt.require-claims"),
+            "sub=alice",
+        )
+        .unwrap();
+
+        let root = tempfile::tempdir().unwrap();
+        let auth = create_jwt_authenticator(
+            JwtCliOptions {
+                issuer: Some(TEST_ISSUER.to_string()),
+                audience: Some(TEST_AUDIENCE.to_string()),
+                require_claims: vec!["sub=bob".to_string()],
+                ..Default::default()
+            },
+            Some(creds.path()),
+            root.path(),
+        )
+        .unwrap()
+        .expect("issuer enables JWT auth");
+
+        let token = issuer.mint(&valid_claims("bob"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("the CLI require-claim should apply");
+
+        let token = issuer.mint(&valid_claims("alice"));
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "CLI --require-claim must replace the credential's rules, not merge"
+        );
+    }
+
+    #[test]
+    fn test_jwt_disabled_without_issuer() {
+        let creds = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let result =
+            create_jwt_authenticator(JwtCliOptions::default(), Some(creds.path()), root.path())
+                .unwrap();
+        assert!(
+            result.is_none(),
+            "no issuer anywhere -> JWT auth not enabled"
+        );
+    }
+
+    #[test]
+    fn test_jwt_etc_jwks_file_wins_over_discovery() {
+        let issuer = TestIssuer::es256();
+        let root = tempfile::tempdir().unwrap();
+        let etc = root.path().join("etc/varlink-httpd");
+        std::fs::create_dir_all(&etc).unwrap();
+        let jwks = json!({ "keys": [issuer.jwk()] });
+        std::fs::write(
+            etc.join("issuer-jwks.json"),
+            serde_json::to_vec(&jwks).unwrap(),
+        )
+        .unwrap();
+
+        // TEST_ISSUER is an https URL, but the pinned file must win (with a
+        // warning) and no discovery fetch must happen.
+        let auth = create_jwt_authenticator(
+            JwtCliOptions {
+                issuer: Some(TEST_ISSUER.to_string()),
+                audience: Some(TEST_AUDIENCE.to_string()),
+                require_claims: vec!["sub=alice".to_string()],
+                ..Default::default()
+            },
+            None,
+            root.path(),
+        )
+        .unwrap()
+        .expect("issuer enables JWT auth");
+
+        let token = issuer.mint(&valid_claims("alice"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("pinned /etc JWKS should verify the token without discovery");
+    }
+
+    #[test]
+    fn test_jwt_other_flags_without_issuer_disabled() {
+        // audience/jwks/require-claim given but no issuer: still disabled (the
+        // flags are ignored, with a warning), not enabled wide open.
+        let creds = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let result = create_jwt_authenticator(
+            JwtCliOptions {
+                audience: Some(TEST_AUDIENCE.to_string()),
+                require_claims: vec!["sub=alice".to_string()],
+                ..Default::default()
+            },
+            Some(creds.path()),
+            root.path(),
+        )
+        .unwrap();
+        assert!(
+            result.is_none(),
+            "JWT flags without an issuer must not enable JWT auth"
+        );
+    }
+
+    #[test]
+    fn test_jwt_not_enabled_without_rules() {
+        let issuer = TestIssuer::es256();
+        let (_dir, jwks_path) = issuer.write_jwks();
+        let root = tempfile::tempdir().unwrap();
+        // Issuer + audience but no --require-claim: JWT is left off (not wide-open),
+        // without failing the whole bridge.
+        let result = create_jwt_authenticator(
+            JwtCliOptions {
+                issuer: Some(TEST_ISSUER.to_string()),
+                audience: Some(TEST_AUDIENCE.to_string()),
+                issuer_jwks: Some(jwks_path),
+                ..Default::default()
+            },
+            None,
+            root.path(),
+        )
+        .unwrap();
+        assert!(result.is_none(), "no rules -> JWT auth not enabled");
+    }
+
+    #[test]
+    fn test_jwt_rejects_expired() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims["exp"] = json!(now_secs() - 120); // beyond the 60s leeway
+        claims["iat"] = json!(now_secs() - 300);
+        let token = issuer.mint(&claims);
+        let err =
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "expected verification failure for expired token, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_future_nbf() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims["nbf"] = json!(now_secs() + 120); // not valid yet, beyond the 60s leeway
+        let token = issuer.mint(&claims);
+        let err =
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "expected verification failure for not-yet-valid (nbf) token, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_wrong_issuer() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims["iss"] = json!("https://evil.example");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "token with wrong issuer should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_wrong_audience() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims["aud"] = json!("node-2");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "token minted for another node's audience should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_missing_audience() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims.as_object_mut().unwrap().remove("aud");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "a token omitting aud must not bypass the per-node audience check"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_missing_issuer() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let mut claims = valid_claims("alice");
+        claims.as_object_mut().unwrap().remove("iss");
+        let token = issuer.mint(&claims);
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "a token omitting iss must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_token_signed_by_untrusted_key() {
+        // JWKS belongs to `trusted`; the token is signed by `attacker`.
+        let trusted = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&trusted);
+
+        let mut attacker = TestIssuer::es256();
+        attacker.kid = trusted.kid.clone(); // even claiming the same kid must not help
+        let token = attacker.mint(&valid_claims("alice"));
+        assert!(
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None).is_err(),
+            "token signed by an untrusted key must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_jwt_rejects_non_bearer_scheme() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let token = issuer.mint(&valid_claims("alice"));
+        let dpop = format!("DPoP {token}");
+        let err = check_request(&auth, "GET", "/sockets", Some(&dpop), None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("scheme must be 'Bearer'"),
+            "non-Bearer scheme should be rejected in stage-1, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jwt_accepts_case_insensitive_bearer_scheme() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let token = issuer.mint(&valid_claims("alice"));
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&format!("bearer {token}")),
+            None,
+            None,
+        )
+        .expect("lowercase scheme should be accepted");
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&format!("BEARER {token}")),
+            None,
+            None,
+        )
+        .expect("uppercase scheme should be accepted");
+    }
+
+    #[test]
+    fn test_jwt_picks_up_rotated_key_on_reload() {
+        // Start trusting issuer A, then rotate the JWKS file to issuer B's key.
+        let issuer_a = TestIssuer::es256();
+        let (dir, jwks_path) = issuer_a.write_jwks();
+        let auth = JwtAuthenticator::new_for_test(
+            TEST_ISSUER.to_string(),
+            TEST_AUDIENCE.to_string(),
+            jwks_path.clone(),
+            vec!["sub=anyone".to_string()],
+        )
+        .unwrap();
+
+        let token_a = issuer_a.mint(&valid_claims("anyone"));
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&bearer(&token_a)),
+            None,
+            None,
+        )
+        .expect("token from the initially-trusted key should pass");
+
+        // Rotate: overwrite the JWKS with a different issuer key (same kid).
+        let mut issuer_b = TestIssuer::es256();
+        issuer_b.kid = issuer_a.kid.clone();
+        let jwks = json!({ "keys": [issuer_b.jwk()] });
+        // Ensure a new mtime even on coarse-grained filesystems.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&jwks_path, serde_json::to_vec(&jwks).unwrap()).unwrap();
+
+        let token_b = issuer_b.mint(&valid_claims("anyone"));
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&bearer(&token_b)),
+            None,
+            None,
+        )
+        .expect("after reload, token from the rotated key should pass");
+        // The old key is gone, so its token must now be rejected.
+        assert!(
+            check_request(
+                &auth,
+                "GET",
+                "/sockets",
+                Some(&bearer(&token_a)),
+                None,
+                None
+            )
+            .is_err(),
+            "after rotation the old key's token should be rejected"
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn test_jwt_keeps_keys_when_jwks_becomes_invalid_then_recovers() {
+        let issuer = TestIssuer::es256();
+        let (dir, jwks_path) = issuer.write_jwks();
+        let auth = JwtAuthenticator::new_for_test(
+            TEST_ISSUER.to_string(),
+            TEST_AUDIENCE.to_string(),
+            jwks_path.clone(),
+            vec!["sub=anyone".to_string()],
+        )
+        .unwrap();
+        let token = issuer.mint(&valid_claims("anyone"));
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("initial key should pass");
+
+        // Overwrite with garbage: the previous keys must be retained, and (with
+        // the mtime now recorded) repeated requests must keep validating.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&jwks_path, b"not json").unwrap();
+        for _ in 0..3 {
+            check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+                .expect("a broken JWKS file must not drop the working keys");
+        }
+
+        // A later valid rewrite is still picked up.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(
+            &jwks_path,
+            serde_json::to_vec(&json!({ "keys": [issuer.jwk()] })).unwrap(),
+        )
+        .unwrap();
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("after a valid rewrite the keys should reload");
+        drop(dir);
+    }
+
+    #[test]
+    fn test_jwt_authenticator_debug() {
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let s = format!("{auth:?}");
+        assert!(s.contains("JwtAuthenticator"), "got: {s}");
+        // one key loaded, lock healthy -> rendered as the count, not <poisoned>
+        assert!(s.contains("key_count: 1"), "got: {s}");
+    }
+
+    // --- end-to-end through the HTTP auth middleware ---
+
+    fn make_router(authenticators: Vec<Box<dyn Authenticator>>) -> Router {
+        let tmpdir = tempfile::tempdir().unwrap();
+        // /sockets over an empty dir returns an empty list with 200, which is
+        // all we need to prove the request made it past the auth middleware.
+        let path = tmpdir.keep();
+        create_router(path.to_str().unwrap(), authenticators).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_jwt_http_accepts_valid_and_rejects_invalid() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let issuer = TestIssuer::es256();
+        let (_dir, auth) = auth_with_allowlist(&issuer);
+        let app = make_router(vec![Box::new(auth)]);
+
+        // Valid token for an allowlisted sub -> request reaches the handler.
+        let token = issuer.mint(&valid_claims("alice"));
+        let ok = app
+            .clone()
+            .oneshot(
+                Request::get("/sockets")
+                    .header("Authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::OK);
+
+        // Garbage token -> 401.
+        let bad = app
+            .clone()
+            .oneshot(
+                Request::get("/sockets")
+                    .header("Authorization", "Bearer not-a-jwt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bad.status(), StatusCode::UNAUTHORIZED);
+
+        // No Authorization header at all -> 401.
+        let missing = app
+            .oneshot(Request::get("/sockets").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Build a JWT-only TLS server (issuer JWKS + `sub` allowlist) and return it
+    /// together with the issuer, the temp dirs to keep alive, and a fake
+    /// `XDG_CONFIG_HOME` holding the server CA so the client trusts the server.
+    /// Mirrors the setup of `sshauth_tests::test_tls_ssh_e2e`.
+    async fn jwt_tls_server() -> (
+        TestIssuer,
+        TestServer<std::net::SocketAddr>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        TestPki,
+    ) {
+        let pki = make_test_pki();
+        let issuer = TestIssuer::es256();
+        let (jwks_dir, jwks_path) = issuer.write_jwks();
+        let auth = JwtAuthenticator::new_for_test(
+            TEST_ISSUER.to_string(),
+            TEST_AUDIENCE.to_string(),
+            jwks_path,
+            vec!["sub=alice".to_string()],
+        )
+        .unwrap();
+
+        let acceptor = load_tls_acceptor(
+            pki.server_cert_path.to_str().unwrap(),
+            pki.server_key_path.to_str().unwrap(),
+            None,
+        )
+        .unwrap();
+        let server =
+            run_test_tls_server_with_auth("/run/systemd", acceptor, vec![Box::new(auth)]).await;
+
+        let fake_xdg_home = tempfile::tempdir().unwrap();
+        let tls_dir = fake_xdg_home.path().join("varlinkctl-http");
+        std::fs::create_dir_all(&tls_dir).unwrap();
+        std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
+
+        (issuer, server, jwks_dir, fake_xdg_home, pki)
+    }
+
+    /// Full TLS client→server flow, the JWT analogue of `test_tls_ssh_e2e`:
+    /// varlinkctl drives `varlinkctl-http`, which reads `VARLINK_JWT` and sends
+    /// `Authorization: Bearer <token>` on the websocket upgrade; the server
+    /// verifies it against the issuer JWKS over a real TLS connection.
+    #[test_with::path(/usr/bin/openssl)]
+    #[test_with::path(/usr/bin/varlinkctl)]
+    #[test_with::path(/run/systemd/io.systemd.Hostname)]
+    #[tokio::test]
+    async fn test_tls_jwt_bearer_e2e() {
+        let (issuer, server, _jwks_dir, fake_xdg_home, _pki) = jwt_tls_server().await;
+        let bridge_url = format!(
+            "https://localhost:{}/ws/sockets/io.systemd.Hostname",
+            server.addr.port()
+        );
+        let token = issuer.mint(&valid_claims("alice"));
+
+        let output = tokio::process::Command::new("varlinkctl")
+            .args([
+                "call",
+                "--json=short",
+                &format!("exec:{}", helper_binary().display()),
+                "io.systemd.Hostname.Describe",
+                "{}",
+            ])
+            .env("VARLINK_BRIDGE_URL", &bridge_url)
+            .env("XDG_CONFIG_HOME", fake_xdg_home.path())
+            .env("VARLINK_JWT", &token)
+            // make sure no ambient ssh-agent interferes with the JWT path
+            .env_remove("SSH_AUTH_SOCK")
+            .env_remove("VARLINK_SSH_KEY")
+            .output()
+            .await
+            .expect("failed to run varlinkctl");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "varlinkctl with TLS + JWT bearer failed (stderr: {stderr})"
+        );
+
+        let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+        let line = stdout.trim().trim_start_matches('\x1e');
+        let body: Value = serde_json::from_str(line).expect("invalid JSON");
+        let expected_hostname = gethostname().into_string().expect("failed to get hostname");
+        assert_eq!(body["Hostname"], expected_hostname);
+    }
+
+    /// Same TLS setup, but without `VARLINK_JWT` the client sends no bearer
+    /// token, so the JWT-only server rejects the upgrade and varlinkctl fails.
+    #[test_with::path(/usr/bin/openssl)]
+    #[test_with::path(/usr/bin/varlinkctl)]
+    #[test_with::path(/run/systemd/io.systemd.Hostname)]
+    #[tokio::test]
+    async fn test_tls_jwt_bearer_e2e_no_token_rejected() {
+        let (_issuer, server, _jwks_dir, fake_xdg_home, _pki) = jwt_tls_server().await;
+        let bridge_url = format!(
+            "https://localhost:{}/ws/sockets/io.systemd.Hostname",
+            server.addr.port()
+        );
+
+        let output = tokio::process::Command::new("varlinkctl")
+            .args([
+                "call",
+                "--json=short",
+                &format!("exec:{}", helper_binary().display()),
+                "io.systemd.Hostname.Describe",
+                "{}",
+            ])
+            .env("VARLINK_BRIDGE_URL", &bridge_url)
+            .env("XDG_CONFIG_HOME", fake_xdg_home.path())
+            .env_remove("VARLINK_JWT")
+            .env_remove("SSH_AUTH_SOCK")
+            .env_remove("VARLINK_SSH_KEY")
+            .output()
+            .await
+            .expect("failed to run varlinkctl");
+
+        assert!(
+            !output.status.success(),
+            "varlinkctl without a JWT should be rejected by the JWT-only server"
+        );
+    }
+
+    /// End-to-end URL mode: a local OIDC issuer serves the discovery document
+    /// and JWKS over HTTP; the authenticator fetches the keys by URL (no file)
+    /// and verifies a token signed by that issuer.
+    #[tokio::test]
+    async fn test_jwt_url_discovery_e2e() {
+        use axum::Router;
+        use axum::routing::get;
+
+        let issuer = TestIssuer::es256();
+        let jwks_json = json!({ "keys": [issuer.jwk()] }).to_string();
+
+        // Bind first so we know the port to advertise in the discovery doc.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let discovery = json!({ "issuer": base, "jwks_uri": format!("{base}/jwks") }).to_string();
+
+        let app = Router::new()
+            .route(
+                "/.well-known/openid-configuration",
+                get(move || {
+                    let d = discovery.clone();
+                    async move { ([("content-type", "application/json")], d) }
+                }),
+            )
+            .route(
+                "/jwks",
+                get(move || {
+                    let j = jwks_json.clone();
+                    async move { ([("content-type", "application/json")], j) }
+                }),
+            );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        // Build the authenticator in URL mode (no jwks file): it fetches the
+        // discovery doc + JWKS at startup. Run it off the async worker since the
+        // fetch is blocking.
+        let root = tempfile::tempdir().unwrap();
+        let root_path = root.path().to_path_buf();
+        let issuer_url = base.clone();
+        let auth = tokio::task::spawn_blocking(move || {
+            create_jwt_authenticator(
+                JwtCliOptions {
+                    issuer: Some(issuer_url),
+                    audience: Some(TEST_AUDIENCE.to_string()),
+                    // no issuer_jwks: forces URL/discovery mode
+                    require_claims: vec!["sub=alice".to_string()],
+                    ..Default::default()
+                },
+                None,
+                &root_path,
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap()
+        .expect("issuer URL should enable JWT auth");
+
+        // Token's iss must match the configured issuer (the server URL).
+        let claims = json!({
+            "iss": base,
+            "aud": TEST_AUDIENCE,
+            "sub": "alice",
+            "exp": now_secs() + 300,
+            "iat": now_secs(),
+        });
+        let token = issuer.mint(&claims);
+        check_request(&auth, "GET", "/sockets", Some(&bearer(&token)), None, None)
+            .expect("token should verify against the discovered JWKS");
+
+        server.abort();
+    }
+} // mod jwtauth_tests

--- a/src/bin/varlinkctl-http/client_auth.rs
+++ b/src/bin/varlinkctl-http/client_auth.rs
@@ -9,6 +9,7 @@
 use anyhow::Result;
 use futures_util::future::LocalBoxFuture;
 use log::{debug, warn};
+use tokio_tungstenite::tungstenite;
 
 pub(crate) trait ClientAuth {
     fn name(&self) -> &'static str;
@@ -29,15 +30,24 @@ pub(crate) trait ClientAuth {
 
 /// Always compiled, so a credential whose method is compiled out warns
 /// instead of being silently ignored.
-const METHOD_FEATURES: &[(&str, &str, bool)] =
-    &[("VARLINK_SSH_KEY", "sshauth", cfg!(feature = "sshauth"))];
+const METHOD_FEATURES: &[(&str, &str, bool)] = &[
+    ("VARLINK_JWT", "jwtauth", cfg!(feature = "jwtauth")),
+    ("VARLINK_SSH_KEY", "sshauth", cfg!(feature = "sshauth")),
+];
 
 /// In precedence order.
 fn methods() -> Vec<&'static dyn ClientAuth> {
     vec![
+        #[cfg(feature = "jwtauth")]
+        &crate::jwt_client::JwtBearer,
         #[cfg(feature = "sshauth")]
         &crate::sshauth_client::SshSignature,
     ]
+}
+
+pub(crate) fn is_http_unauthorized(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<tungstenite::Error>()
+        .is_some_and(|e| matches!(e, tungstenite::Error::Http(r) if r.status() == 401))
 }
 
 pub(crate) async fn connect_ws(url: &str) -> Result<crate::Ws> {

--- a/src/bin/varlinkctl-http/jwt_client.rs
+++ b/src/bin/varlinkctl-http/jwt_client.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Client-side JWT bearer support
+//!
+//! The Bearer mode needs no client-side crypto: the token is obtained out of
+//! band (pasted, piped from a CI OIDC endpoint, or minted by an issuer helper)
+//! and simply attached as `Authorization: Bearer <JWT>`. The proof-of-possession
+//! modes (RFC 9421 and `DPoP`) will add request signing here later.
+
+use anyhow::{Context, Result};
+use futures_util::future::LocalBoxFuture;
+use log::debug;
+
+use crate::client_auth::{ClientAuth, is_http_unauthorized};
+
+/// Environment variable carrying the bearer token itself (not a path, unlike
+/// `VARLINK_SSH_KEY`); surrounding whitespace is trimmed so a token piped in
+/// with a trailing newline still works.
+const VARLINK_JWT_ENV: &str = "VARLINK_JWT";
+
+pub(crate) struct JwtBearer;
+
+impl ClientAuth for JwtBearer {
+    fn name(&self) -> &'static str {
+        "JWT bearer auth (VARLINK_JWT)"
+    }
+
+    fn configured(&self) -> bool {
+        std::env::var_os(VARLINK_JWT_ENV).is_some()
+    }
+
+    fn connect<'a>(&'a self, url: &'a str) -> LocalBoxFuture<'a, Result<Option<crate::Ws>>> {
+        Box::pin(async move {
+            let Ok(token) = std::env::var(VARLINK_JWT_ENV) else {
+                return Ok(None);
+            };
+            let token = token.trim();
+            if token.is_empty() {
+                return Ok(None);
+            }
+
+            let (stream, mut request, tcb) = crate::connect_transport(url).await?;
+            request.headers_mut().insert(
+                "Authorization",
+                format!("Bearer {token}")
+                    .parse()
+                    .context("VARLINK_JWT is not a valid HTTP header value")?,
+            );
+            debug!("JWT auth: attached bearer token from {VARLINK_JWT_ENV}");
+            match crate::ws_upgrade(request, stream, tcb.is_some()).await {
+                Ok(ws) => Ok(Some(ws)),
+                Err(e) if is_http_unauthorized(&e) => {
+                    Err(e.context("the VARLINK_JWT bearer token was rejected; is it expired?"))
+                }
+                Err(e) => Err(e),
+            }
+        })
+    }
+}

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+// Reduced-feature builds leave some shared auth plumbing unused; the
+// default all-features build still gets full dead-code checking.
+#![cfg_attr(not(any(feature = "sshauth", feature = "jwtauth")), allow(dead_code))]
+
 use std::os::fd::BorrowedFd;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -17,6 +21,8 @@ use tokio_tungstenite::tungstenite::{self, Message};
 use varlink_http_bridge::TlsChannelBinding;
 
 mod client_auth;
+#[cfg(feature = "jwtauth")]
+mod jwt_client;
 #[cfg(feature = "sshauth")]
 mod sshauth_client;
 
@@ -579,7 +585,7 @@ mod tests {
         async fn test_ws_handshake_401_is_detected_as_unauthorized() {
             let err =
                 handshake_error("HTTP/1.1 401 Unauthorized\r\ncontent-length: 0\r\n\r\n").await;
-            assert!(sshauth_client::is_http_unauthorized(&err), "{err:#}");
+            assert!(client_auth::is_http_unauthorized(&err), "{err:#}");
         }
 
         #[tokio::test]
@@ -587,7 +593,7 @@ mod tests {
             let err =
                 handshake_error("HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\n\r\n")
                     .await;
-            assert!(!sshauth_client::is_http_unauthorized(&err), "{err:#}");
+            assert!(!client_auth::is_http_unauthorized(&err), "{err:#}");
         }
     }
 }

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -8,7 +8,7 @@ use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
 use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding};
 
-use crate::client_auth::ClientAuth;
+use crate::client_auth::{ClientAuth, is_http_unauthorized};
 
 /// An SSH key that can be used for authentication.
 enum SshKey {
@@ -171,11 +171,6 @@ impl fmt::Display for SigningFailed {
 
 fn is_signing_failure(err: &anyhow::Error) -> bool {
     err.is::<SigningFailed>()
-}
-
-pub(crate) fn is_http_unauthorized(err: &anyhow::Error) -> bool {
-    err.downcast_ref::<tungstenite::Error>()
-        .is_some_and(|e| matches!(e, tungstenite::Error::Http(r) if r.status() == 401))
 }
 
 /// Return all available SSH keys for authentication.

--- a/src/sysconf.rs
+++ b/src/sysconf.rs
@@ -29,6 +29,31 @@ impl CredentialsLoader {
         let path = self.dir.join(id);
         path.exists().then_some(path)
     }
+
+    /// Trimmed content of a scalar credential, if present and non-empty.
+    #[must_use]
+    pub fn get_string(&self, id: &str) -> Option<String> {
+        let path = self.path(id)?;
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
+    /// Non-empty, non-`#` lines of a list credential.
+    #[must_use]
+    pub fn get_lines(&self, id: &str) -> Vec<String> {
+        self.path(id)
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .map(|s| {
+                s.lines()
+                    .map(str::trim)
+                    .filter(|l| !l.is_empty() && !l.starts_with('#'))
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 /// Highest-precedence existing config file for `rel`, following the systemd
@@ -54,6 +79,22 @@ mod tests {
         let loader = CredentialsLoader::from_dir(dir.path());
         assert_eq!(loader.path("cert"), Some(dir.path().join("cert")));
         assert_eq!(loader.path("missing"), None);
+    }
+
+    #[test]
+    fn test_credentials_loader_content() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("scalar"), "  value\n").unwrap();
+        std::fs::write(dir.path().join("list"), "a\n# comment\n\n b \n").unwrap();
+
+        let loader = CredentialsLoader::from_dir(dir.path());
+        assert_eq!(loader.get_string("scalar").as_deref(), Some("value"));
+        assert_eq!(loader.get_string("missing"), None);
+        assert_eq!(
+            loader.get_lines("list"),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(loader.get_lines("missing"), Vec::<String>::new());
     }
 
     #[test]


### PR DESCRIPTION
[draft until #87  and #85 and #84 are merged]

This commit adds basic support for authentication via a
Json Web Token (JWT). This works by adding a new JwtAuthenticator
to the bridge. The keys (jwks) can come from a local file or from
a URL (and can be auto-discovered).

That takes the following parameters (via cli or systemd credentials):
```
--issuer=URL                accepted 'iss' claim
--audience=ID               accepted 'aud' claim (default: hostname)
--issuer-jwks=PATH          (optional) issuer JWKS file (RS256/ES256 public keys)
--require-claim=NAME=VALUE  require claim NAME to match VALUE (repeatable)
```

There must be at least one required claim (currently) to ensure
the bridge is not too open. In many setups (e.g. GH) the "aud" is
caller-controlled so it cannot be a security boundary. Ensure that
the issuer claims cannot be forged (e.g. repository= on github
OIDC).

Note that this is bearer token only for now. Doing PoP (RFC 9421/DPoP)
is planned but this commit is already quite long.
