### PR TITLE
crates: create ssh-key-import crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "LGPL-2.1-or-later"
 
+[workspace]
+members = [".", "crates/ssh-key-import"]
+
 [[bin]]
 name = "varlink-httpd"
 path = "src/bin/varlink-httpd/main.rs"
@@ -14,7 +17,7 @@ path = "src/bin/varlinkctl-http/main.rs"
 
 [features]
 default = ["sshauth"]
-sshauth = ["dep:ssh-key", "dep:sshauth", "dep:ureq", "dep:tempfile"]
+sshauth = ["dep:ssh-key", "dep:sshauth", "dep:tempfile", "dep:ssh-key-import"]
 
 [dependencies]
 anyhow = "1.0.100"
@@ -49,8 +52,8 @@ tokio-openssl = "0.6"
 indoc = "2.0.7"
 ssh-key = { version = "0.6", optional = true }
 sshauth = { version = "0.1", optional = true }
-ureq = { version = "3", optional = true, default-features = false, features = ["native-tls"] }
 tempfile = { version = "3.27", optional = true }
+ssh-key-import = { path = "crates/ssh-key-import", optional = true }
 
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }

--- a/crates/ssh-key-import/Cargo.toml
+++ b/crates/ssh-key-import/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ssh-key-import"
+version = "0.1.0"
+edition = "2024"
+license = "LGPL-2.1-or-later"
+
+[dependencies]
+anyhow = "1.0.100"
+ssh-key = "0.6"
+sshauth = "0.1"
+tempfile = "3.27"
+ureq = { version = "3", default-features = false, features = ["native-tls"] }

--- a/crates/ssh-key-import/src/lib.rs
+++ b/crates/ssh-key-import/src/lib.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Fetch and validate SSH `authorized_keys` from a remote source.
+//!
+//! Shared by `varlink-httpd import-ssh` and `amutablectl` so the
+//! `gh:<user>` / `https://` resolution and key validation live in one
+//! place instead of being duplicated per consumer.
+
+use anyhow::{Context, bail};
+use std::io::Write as _;
+
+pub use ssh_key;
+
+/// A validated set of authorized keys.
+pub struct AuthorizedKeys {
+    /// The raw response text, exactly as fetched, suitable to persist verbatim.
+    pub text: String,
+    /// The parsed public keys (guaranteed non-empty when returned from [`fetch`]).
+    pub keys: Vec<ssh_key::PublicKey>,
+}
+
+/// Resolve a key `source` to an `https://` URL.
+///
+/// Accepts `gh:<user>` (that user's published GitHub keys) or a literal
+/// `https://` URL. Other schemes (including plain `http://`) are rejected:
+/// the fetched keys are trusted verbatim, so the transport must be
+/// authenticated.
+///
+/// # Errors
+/// Fails if `source` is neither `gh:<user>` nor an `https://` URL.
+pub fn resolve_key_url(source: &str) -> anyhow::Result<String> {
+    if let Some(user) = source.strip_prefix("gh:") {
+        Ok(format!("https://github.com/{user}.keys"))
+    } else if source.starts_with("https://") {
+        Ok(source.to_string())
+    } else {
+        bail!("unsupported source: {source} (use `gh:<user>` or an `https://` URL)")
+    }
+}
+
+/// Fetch authorized keys from `source`, validate them, and return the raw
+/// text together with the parsed keys.
+///
+/// # Errors
+/// Fails if the source is unsupported, the HTTP request fails, or the
+/// response contains no valid SSH public keys (e.g. an HTML error page
+/// from a mistyped URL).
+pub fn fetch(source: &str) -> anyhow::Result<AuthorizedKeys> {
+    let url = resolve_key_url(source)?;
+
+    let tls = ureq::tls::TlsConfig::builder()
+        .provider(ureq::tls::TlsProvider::NativeTls)
+        .build();
+    let agent = ureq::config::Config::builder()
+        .tls_config(tls)
+        .build()
+        .new_agent();
+    let text = agent
+        .get(&url)
+        .call()
+        .with_context(|| format!("failed to fetch keys from {url}"))?
+        .body_mut()
+        .with_config()
+        // 640KB ought to be enough for anybody (default of 10mb is a bit much)
+        .limit(640 * 1024)
+        .read_to_string()
+        .with_context(|| format!("failed to read response body from {url}"))?;
+
+    let keys = validate(&text)
+        .with_context(|| format!("response from {url} contains invalid SSH public keys"))?;
+    if keys.is_empty() {
+        bail!("no valid SSH public keys found in response from {url}");
+    }
+
+    Ok(AuthorizedKeys { text, keys })
+}
+
+/// Parse `text` as an `authorized_keys` file and return the public keys.
+///
+/// # Errors
+/// Fails if `text` is not valid `authorized_keys` syntax.
+pub fn validate(text: &str) -> anyhow::Result<Vec<ssh_key::PublicKey>> {
+    // sshauth parses from a path, so stage the bytes in a tempfile.
+    let mut tmp = tempfile::NamedTempFile::new().context("failed to create tempfile")?;
+    tmp.write_all(text.as_bytes())
+        .context("failed to write tempfile")?;
+    sshauth::keyfile::parse_authorized_keys(tmp.path(), true)
+        .context("failed to parse authorized keys")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_gh_shorthand() {
+        assert_eq!(
+            resolve_key_url("gh:octocat").unwrap(),
+            "https://github.com/octocat.keys"
+        );
+    }
+
+    #[test]
+    fn resolve_https_passthrough() {
+        let url = "https://example.com/keys";
+        assert_eq!(resolve_key_url(url).unwrap(), url);
+    }
+
+    #[test]
+    fn resolve_rejects_other_schemes() {
+        assert!(resolve_key_url("http://example.com/keys").is_err());
+        assert!(resolve_key_url("octocat").is_err());
+        assert!(resolve_key_url("ftp://example.com").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_garbage() {
+        assert!(validate("<!DOCTYPE html><html>not a key</html>").is_err());
+    }
+}

--- a/src/bin/varlink-httpd/import_ssh.rs
+++ b/src/bin/varlink-httpd/import_ssh.rs
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 use std::io::Write;
 
 #[derive(Debug)]
 pub(crate) struct ImportSsh {
     pub source: String,
     pub output: Option<String>,
-}
-
-fn resolve_key_url(source: &str) -> anyhow::Result<String> {
-    if let Some(user) = source.strip_prefix("gh:") {
-        Ok(format!("https://github.com/{user}.keys"))
-    } else if source.starts_with("https://") {
-        Ok(source.to_string())
-    } else {
-        bail!("unsupported source: {source} (use `gh:<user>` or an `https://` URL)")
-    }
 }
 
 fn default_authorized_keys_path() -> String {
@@ -43,26 +33,12 @@ fn default_authorized_keys_path() -> String {
 }
 
 pub(crate) fn run(cmd: ImportSsh) -> anyhow::Result<()> {
-    let url = resolve_key_url(&cmd.source)?;
-
     let output_path = cmd.output.unwrap_or_else(default_authorized_keys_path);
 
-    let tls = ureq::tls::TlsConfig::builder()
-        .provider(ureq::tls::TlsProvider::NativeTls)
-        .build();
-    let agent = ureq::config::Config::builder()
-        .tls_config(tls)
-        .build()
-        .new_agent();
-    let body = agent
-        .get(&url)
-        .call()
-        .with_context(|| format!("failed to fetch keys from {url}"))?
-        .body_mut()
-        .with_config()
-        .limit(640 * 1024) // 640KB ought to be enough for anybody (default of 10mb is a bit much)
-        .read_to_string()
-        .with_context(|| format!("failed to read response body from {url}"))?;
+    // Fetch and validate up front. A typo in the URL returning an HTML
+    // page instead of keys must not overwrite a good authorized_keys file
+    // and lock out all users.
+    let imported = ssh_key_import::fetch(&cmd.source)?;
 
     let out = std::path::Path::new(&output_path);
     let parent = out
@@ -71,29 +47,20 @@ pub(crate) fn run(cmd: ImportSsh) -> anyhow::Result<()> {
     std::fs::create_dir_all(parent)
         .with_context(|| format!("failed to create directory {}", parent.display()))?;
 
-    // Write to tempfile first...
+    // Write to a tempfile in the target directory, then rename, so a
+    // reader never observes a partially-written authorized_keys.
     let mut tmp_authorized_keys = tempfile::NamedTempFile::new_in(parent)
         .with_context(|| format!("failed to create tempfile in {}", parent.display()))?;
     tmp_authorized_keys
-        .write_all(body.as_bytes())
+        .write_all(imported.text.as_bytes())
         .with_context(|| format!("failed to write tempfile in {}", parent.display()))?;
-
-    // Then validate before committing. A typo in the URL returning an
-    // HTML page instead of the keys would otherwise overwrite a good
-    // authorized_keys file and lock out all users.
-    let keys = sshauth::keyfile::parse_authorized_keys(tmp_authorized_keys.path(), true)
-        .with_context(|| format!("response from {url} contains invalid SSH public keys"))?;
-    if keys.is_empty() {
-        bail!("no valid SSH public keys found in response from {url}");
-    }
-
     tmp_authorized_keys
         .persist(out)
         .with_context(|| format!("failed to rename tempfile to {output_path}"))?;
 
     eprintln!(
         "Wrote {keys_count} key(s) to {output_path}, run with:",
-        keys_count = keys.len()
+        keys_count = imported.keys.len()
     );
     if std::env::var_os("CREDENTIALS_DIRECTORY").is_some() {
         eprintln!("  varlink-httpd");


### PR DESCRIPTION
This commit shuffles the code from varlink-httpd/import_ssh.rs into its own crate. This allows re-using the code from other projects.