### PR TITLE
cargo: add `lto = true` and `codegen-units = 1` to release  builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,5 @@ tower = { version = "0.5", features = ["util"] }
 
 [profile.release]
 strip = true
+lto = true
+codegen-units = 1

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ test:
 # the httpd service
 srv_binary := "target/release/varlink-httpd"
 # max_size_kb is a bit arbitrary but it should ensure we don't increase size too much
-# without noticing (currently at 3.2MB)
+# without noticing
 srv_max_size := "4 * 1024 * 1024"
 
 # the varlinkctl http transport so that varlinkctl can talk over http/ws
@@ -51,7 +51,7 @@ check_srv_binary_size:
 	cargo build --release
 	max_size_kb="$(({{srv_max_size}} / 1024 ))"
 	cur_size_kb=$(( $(stat --format='%s' {{srv_binary}}) / 1024 ))
-	echo "release binary: ${cur_size_kb}KB / ${max_size_kb}KB"
+	echo "release varlink-httpd binary: ${cur_size_kb}KB / ${max_size_kb}KB"
 	if [ "$cur_size_kb" -gt "$max_size_kb" ]; then
 	  echo "ERROR: release binary exceeds limit"
 	  exit 1


### PR DESCRIPTION
Make our production builds a bit smaller on the expense of build
time for (release) builds. This is a nice improvment, we go from
4088KB -> 3217KB for the varlink-httpd binary.

For reference:
```
$ just check
    Finished `release` profile [optimized] target(s) in 0.23s
release varlink-httpd binary: 3217KB / 4096KB
    Finished `release` profile [optimized] target(s) in 0.07s
release varlinkctl-http binary: 1410KB / 2048KB
```

vs before:
```
$ just check
    Finished `release` profile [optimized] target(s) in 0.12s
rrelease varlink-httpd binary: 4088KB / 4096KB
    Finished `release` profile [optimized] target(s) in 0.07s
release varlinkctl-http binary: 1864KB / 2048KB
```

---

 justfile: show varlink-httpd name and tweak size comment

Trivial change so that `just check` shows the name `varlink-httpd`
instead of just `release binary`.

It also drops the comment what the current size of varlink-httpd
is. The size is stale and having it in a comment is a bit silly
as it will become stale again. So we just drop it, running
just check will report it.


Prompted by #79 which required a size bump that this will allow us to undo.