### PR TITLE
httpd: extract VarlinkFramer helper to simplify forward loop

### DIFF
--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -22,9 +22,8 @@ use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::fs::FileTypeExt;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixStream};
 use tokio::signal;
 use tokio_vsock::VsockListener;
@@ -34,6 +33,9 @@ use zlink::varlink_service::Proxy;
 mod auth_ssh;
 #[cfg(feature = "sshauth")]
 mod import_ssh;
+mod ws_framing;
+
+use ws_framing::VarlinkFramer;
 
 #[cfg(feature = "sshauth")]
 use auth_ssh::{create_ssh_authenticator, extract_nonce};
@@ -786,53 +788,23 @@ async fn route_ws(
     Ok(ws.on_upgrade(move |ws_socket| handle_ws(ws_socket, varlink_stream)))
 }
 
-// Forwards raw bytes between the websocket and the varlink unix
-// socket in both directions. Each NUL-delimited varlink message is
-// sent as one WS binary frame. Once a protocol upgrade happens this is
-// dropped and its just a raw byte stream.
-async fn handle_ws(mut ws: WebSocket, unix: UnixStream) {
-    let (unix_read, mut unix_write) = tokio::io::split(unix);
-    let mut unix_reader = tokio::io::BufReader::new(unix_read);
-    let (varlink_msg_tx, mut varlink_msg_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
-    // the complexity here is a bit ugly but without it the websocket is very hard
-    // to use from tools like "websocat" which will add a \n or \0 after each "message"
-    let varlink_connection_upgraded = Arc::new(AtomicBool::new(false));
+/// Send each frame as one WS binary message.
+async fn send_ws_frames(
+    ws: &mut WebSocket,
+    frames: impl IntoIterator<Item = Vec<u8>>,
+) -> Result<(), axum::Error> {
+    for frame in frames {
+        ws.send(Message::Binary(frame.into())).await?;
+    }
+    Ok(())
+}
 
-    // read_until is not cancel-safe, so run it in a separate task and we need read_until
-    // to ensure we keep the \0 boundaries and send these via a varlink_msg channel.
-    //
-    // After a varlink protocol upgrade the connection carries raw bytes without \0
-    // delimiters, so the reader switches to plain read() once "upgraded" is set.
-    let reader_task = tokio::spawn({
-        let varlink_connection_upgraded = varlink_connection_upgraded.clone();
-        async move {
-            loop {
-                let mut buf = Vec::new();
-                let res = if varlink_connection_upgraded.load(Ordering::Relaxed) {
-                    buf.reserve(8192);
-                    unix_reader.read_buf(&mut buf).await
-                } else {
-                    unix_reader.read_until(0, &mut buf).await
-                };
-                match res {
-                    Err(e) => {
-                        warn!("varlink read error: {e}");
-                        break;
-                    }
-                    Ok(0) => {
-                        debug!("varlink socket closed (read returned 0)");
-                        break;
-                    }
-                    Ok(_) => {
-                        if varlink_msg_tx.send(buf).await.is_err() {
-                            warn!("varlink_msg channel closed, ws gone?");
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    });
+// Forwards bytes between the websocket and the varlink unix socket in
+// both directions; framing decisions live in [`VarlinkFramer`].
+async fn handle_ws(mut ws: WebSocket, unix: UnixStream) {
+    let (mut unix_read, mut unix_write) = tokio::io::split(unix);
+    let mut varlink_framer = VarlinkFramer::new();
+    let mut buf: Vec<u8> = Vec::with_capacity(8192);
 
     loop {
         tokio::select! {
@@ -859,41 +831,38 @@ async fn handle_ws(mut ws: WebSocket, unix: UnixStream) {
                         continue;
                     }
                 };
-                // Detect varlink protocol upgrade request
-                if !varlink_connection_upgraded.load(Ordering::Relaxed) {
-                    let json_bytes = data.strip_suffix(&[0]).unwrap_or(&data);
-                    match serde_json::from_slice::<Value>(json_bytes) {
-                        Ok(v) => {
-                            if v.get("upgrade").and_then(Value::as_bool).unwrap_or(false) {
-                                debug!("varlink protocol upgrade detected");
-                                varlink_connection_upgraded.store(true, Ordering::Relaxed);
-                            }
-                        }
-                        Err(e) => {
-                            warn!("failed to parse ws message as JSON for upgrade detection: {e}");
-                        }
-                    }
-                }
+                varlink_framer.detect_protocol_upgrade_request(&data);
                 if let Err(e) = unix_write.write_all(&data).await {
                     warn!("varlink write error: {e}");
                     break;
                 }
             }
-            Some(data) = varlink_msg_rx.recv() => {
-                if let Err(e) = ws.send(Message::Binary(data.into())).await {
-                    warn!("ws send error: {e}");
-                    break;
+            res = unix_read.read_buf(&mut buf) => {  // this is cancel-safe
+                match res {
+                    Err(e) => {
+                        warn!("varlink read error: {e}");
+                        break;
+                    }
+                    Ok(0) => {
+                        debug!("varlink socket closed (read returned 0)");
+                        if let Err(e) = send_ws_frames(&mut ws, varlink_framer.finish()).await {
+                            warn!("ws send error: {e}");
+                        }
+                        break;
+                    }
+                    Ok(_) => {
+                        let ws_frames = varlink_framer.push_varlink_bytes(&buf);
+                        buf.clear();  // clear() keeps the capacity of buf
+                        if let Err(e) = send_ws_frames(&mut ws, ws_frames).await {
+                            warn!("ws send error: {e}");
+                            break;
+                        }
+                    }
                 }
-            }
-            else => {
-                debug!("select: all branches closed");
-                break;
             }
         }
     }
     debug!("handle_ws loop exited");
-
-    reader_task.abort();
 }
 
 fn create_router(

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -826,8 +826,9 @@ async fn handle_ws(mut ws: WebSocket, unix: UnixStream) {
                         debug!("ws recv close frame: {frame:?}");
                         break;
                     }
-                    other => {
-                        debug!("ws recv other: {other:?}");
+                    msg @ (Message::Ping(_) | Message::Pong(_)) => {
+                        // keepalives; axum answers pings automatically
+                        debug!("ws recv keepalive: {msg:?}");
                         continue;
                     }
                 };

--- a/src/bin/varlink-httpd/ws_framing.rs
+++ b/src/bin/varlink-httpd/ws_framing.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Framing and upgrade detection for the WebSocket <-> varlink byte
+//! bridge, kept free of I/O so it can be unit tested without sockets.
+
+use log::{debug, warn};
+use serde_json::Value;
+
+/// Before a varlink protocol upgrade each NUL-delimited varlink message
+/// becomes one WebSocket frame (delimiter included), which makes the
+/// websocket easy to use from tools like "websocat". After an upgrade
+/// the connection is a raw byte stream and everything passes through
+/// unsplit.
+pub(crate) struct VarlinkFramer {
+    buf: Vec<u8>,
+    upgraded: bool,
+}
+
+impl VarlinkFramer {
+    pub(crate) fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            upgraded: false,
+        }
+    }
+
+    /// Detect a varlink protocol upgrade request (`{"upgrade": true}`)
+    /// in a client->varlink message.
+    pub(crate) fn detect_protocol_upgrade_request(&mut self, data: &[u8]) {
+        if self.upgraded {
+            return;
+        }
+        // tools like "websocat" add a \n or \0 after each "message";
+        // the \0 must be stripped, trailing \n is fine for the parser
+        let json_bytes = data.strip_suffix(&[0]).unwrap_or(data);
+        match serde_json::from_slice::<Value>(json_bytes) {
+            Ok(v) => {
+                if v.get("upgrade").and_then(Value::as_bool).unwrap_or(false) {
+                    debug!("varlink protocol upgrade detected");
+                    self.upgraded = true;
+                }
+            }
+            Err(e) => {
+                warn!("failed to parse ws message as JSON for upgrade detection: {e}");
+            }
+        }
+    }
+
+    /// Feed bytes read from the varlink socket, returning the frames
+    /// ready to be sent to the WebSocket.
+    pub(crate) fn push_varlink_bytes(&mut self, data: &[u8]) -> Vec<Vec<u8>> {
+        self.buf.extend_from_slice(data);
+
+        if self.upgraded {
+            if self.buf.is_empty() {
+                return Vec::new();
+            }
+            return vec![std::mem::take(&mut self.buf)];
+        }
+
+        let mut frames = Vec::new();
+        while let Some(pos) = self.buf.iter().position(|&b| b == 0) {
+            let rest = self.buf.split_off(pos + 1);
+            frames.push(std::mem::replace(&mut self.buf, rest));
+        }
+        frames
+    }
+
+    /// Return any buffered partial message so nothing is lost when the
+    /// varlink socket hits EOF.
+    pub(crate) fn finish(&mut self) -> Option<Vec<u8>> {
+        if self.buf.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.buf))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one_message_per_frame_including_delimiter() {
+        let mut f = VarlinkFramer::new();
+        assert_eq!(
+            f.push_varlink_bytes(b"{\"a\":1}\0{\"b\":2}\0"),
+            vec![b"{\"a\":1}\0".to_vec(), b"{\"b\":2}\0".to_vec()]
+        );
+        assert_eq!(f.finish(), None);
+    }
+
+    #[test]
+    fn test_message_split_across_reads() {
+        let mut f = VarlinkFramer::new();
+        assert!(f.push_varlink_bytes(b"{\"met").is_empty());
+        assert!(f.push_varlink_bytes(b"hod\":\"x\"}").is_empty());
+        assert_eq!(
+            f.push_varlink_bytes(b"\0{\"next").as_slice(),
+            &[b"{\"method\":\"x\"}\0".to_vec()]
+        );
+        assert_eq!(f.finish(), Some(b"{\"next".to_vec()));
+        assert_eq!(f.finish(), None);
+    }
+
+    #[test]
+    fn test_empty_push_yields_no_frames() {
+        let mut f = VarlinkFramer::new();
+        assert!(f.push_varlink_bytes(b"").is_empty());
+        assert_eq!(f.finish(), None);
+    }
+
+    #[test]
+    fn test_upgrade_detection() {
+        let mut f = VarlinkFramer::new();
+
+        f.detect_protocol_upgrade_request(b"{\"method\":\"io.systemd.Hostname.Describe\"}\0");
+        assert!(!f.upgraded);
+        f.detect_protocol_upgrade_request(b"{\"upgrade\":false}\0");
+        assert!(!f.upgraded);
+        f.detect_protocol_upgrade_request(b"not json at all");
+        assert!(!f.upgraded);
+
+        f.detect_protocol_upgrade_request(b"{\"method\":\"m\",\"upgrade\":true}\0");
+        assert!(f.upgraded);
+    }
+
+    #[test]
+    fn test_upgrade_detection_trailing_whitespace() {
+        // websocat appends \n after each message
+        let mut f = VarlinkFramer::new();
+        f.detect_protocol_upgrade_request(b"{\"upgrade\":true}\n");
+        assert!(f.upgraded);
+    }
+
+    #[test]
+    fn test_raw_passthrough_after_upgrade() {
+        let mut f = VarlinkFramer::new();
+        f.detect_protocol_upgrade_request(b"{\"upgrade\":true}\0");
+
+        assert_eq!(
+            f.push_varlink_bytes(b"raw\0bytes\0no framing"),
+            vec![b"raw\0bytes\0no framing".to_vec()]
+        );
+        assert!(f.push_varlink_bytes(b"").is_empty());
+
+        // post-upgrade client bytes must not be parsed (or warned about)
+        f.detect_protocol_upgrade_request(b"\xff\xfe raw upload data");
+        assert!(f.upgraded);
+    }
+
+    #[test]
+    fn test_buffered_partial_flushed_on_upgrade() {
+        let mut f = VarlinkFramer::new();
+        assert!(f.push_varlink_bytes(b"{\"reply\"").is_empty());
+        f.detect_protocol_upgrade_request(b"{\"upgrade\":true}\0");
+        assert_eq!(
+            f.push_varlink_bytes(b":42}\0raw"),
+            vec![b"{\"reply\":42}\0raw".to_vec()]
+        );
+    }
+}


### PR DESCRIPTION
When we do the websocket<->unix socket forwarding the loop was relatively complicated. It mixed I/O and protocol logic. This commit got inspired by the sans-io pattern and refactors so that the protocol logic is now split out from the I/O. This means that the code is simpler and easier to test.

The logic about the Varlink protocol frames is now a new VarlinkFramer helper.

---

httpd: make the websocket message handling arm exhaustive

The websocket data handling had a (slightly) ugly "other" arm
that was hiding `Message::Ping(_) | Message::Pong(_)` messages
that can come via a websocket.
