### PR TITLE
auth: add new api-key authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lexopt = "0.3"
 regex-lite = "0.1"
 listenfd = "1.0.2"
 tokio-tungstenite = "0.30"
+data-encoding = "2"
 futures-util = { version = "0.3" }
 bytes = "1"
 rustix = { version = "1.0", features = ["net", "process"] }

--- a/README.md
+++ b/README.md
@@ -451,3 +451,100 @@ $ varlinkctl call vsock+tls://3/ws/sockets/io.systemd.Hostname \
 The client looks for its certificate and key in the same config
 directories as for TCP (see [Client (varlinkctl-http)](#client-varlinkctl-http)
 below). CID 3+ are guests; CID 2 is the host.
+
+## API key authentication
+
+For plain `curl` (shell scripts, cron jobs, CI) the bridge supports
+static API keys presented as `Authorization: Bearer <key>`. The
+server only stores the SHA-256 hash of each key, so the API keys
+file is not itself a secret.
+
+> **TLS is required in production.** An API key has no
+> proof-of-possession: anyone who captures it can replay it. Only
+> transport TLS (or a non-sniffable transport like vsock) protects it
+> in flight. For stronger per-request authentication use SSH key auth.
+
+### Server setup
+
+Generate a key with the `gen-api-key` subcommand; it prints the key
+to stdout exactly once and appends its hash to the API keys file:
+
+```console
+$ run0 varlink-httpd gen-api-key --name=deploy-script
+vhb_9f8e7d6c5b4a...
+Appended hash of API key 'deploy-script' to /etc/varlink-httpd/api-keys, run with:
+  varlink-httpd
+```
+
+The bridge discovers API key hashes automatically from these locations
+(first match wins):
+
+1. `--api-keys=PATH` - explicit CLI flag
+2. `/etc/varlink-httpd/api-keys` - config file
+3. `$CREDENTIALS_DIRECTORY/api-keys` - systemd credential; the shipped
+   unit imports `varlink-httpd.api-keys` from the credstore (see
+   `systemd.exec(5)`)
+
+The API keys file has one key per line, `sha256:<hex> [name]`, with
+`#` comments allowed. The name identifies the key in logs; revoke a
+key by deleting its line (the file is hot-reloaded, no restart
+needed). To add an externally generated key by hand:
+
+```console
+$ echo "sha256:$(printf %s "$API_KEY" | sha256sum | cut -d' ' -f1) ci-runner" \
+    >> /etc/varlink-httpd/api-keys
+```
+
+### Using it with curl
+
+`gen-api-key` registers the hash on the machine it runs on, so run it
+on the server; only the printed key is copied to the client:
+
+```console
+myhost$ run0 varlink-httpd gen-api-key --name=laptop-cli
+vhb_2048f47eb397b0eed671280444b6f89692170d9ae33a94713681d1a22ea0dc55
+Appended hash of API key 'laptop-cli' to /etc/varlink-httpd/api-keys, run with:
+  varlink-httpd
+```
+
+Then, from anywhere that can reach the bridge:
+
+```console
+$ export API_KEY=vhb_2048f47eb397b0ee...   # the value printed above
+
+$ curl -s -H "Authorization: Bearer $API_KEY" https://myhost:1031/sockets | jq
+{
+  "sockets": [
+    "io.systemd.Hostname",
+...
+
+$ curl -s -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+    -X POST https://myhost:1031/call/io.systemd.Hostname.Describe -d '{}' \
+    | jq .StaticHostname
+"top"
+```
+
+### Client (varlinkctl-http)
+
+The `varlinkctl-http` bridge helper sends the key from
+`VARLINK_API_KEY`, which takes priority over SSH key auth:
+
+```console
+$ VARLINK_API_KEY="$API_KEY" \
+  VARLINK_BRIDGE_URL=https://myhost:1031/ws/sockets/io.systemd.Hostname \
+    varlinkctl call exec:/usr/libexec/varlinkctl-http \
+    io.systemd.Hostname.Describe '{}'
+```
+
+### Provisioning via systemd credentials
+
+Instead of a file in `/etc`, ship the hashes through the credstore;
+the shipped unit imports `varlink-httpd.api-keys` automatically.
+Because the file only contains hashes it can also be generated on one
+machine and copied to the nodes as part of provisioning:
+
+```console
+$ varlink-httpd gen-api-key --name=deploy-script api-keys
+vhb_9f8e7d6c5b4a...
+$ scp api-keys myhost:/etc/credstore/varlink-httpd.api-keys
+```

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -52,5 +52,8 @@ ImportCredential=varlink-httpd.tls.trust:trust
 ImportCredential=ssh.authorized_keys.root
 ImportCredential=ssh.ephemeral-authorized_keys-all
 
+# API key hashes, renamed to the short name matching the --api-keys flag
+ImportCredential=varlink-httpd.api-keys:api-keys
+
 [Install]
 WantedBy=network.target

--- a/src/bin/varlink-httpd/auth_api_key.rs
+++ b/src/bin/varlink-httpd/auth_api_key.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+use anyhow::{Context, bail};
+use data_encoding::{HEXLOWER, HEXLOWER_PERMISSIVE};
+use log::{info, warn};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use crate::Authenticator;
+
+/// Prefix for generated API keys so a leaked key is recognizable
+/// (e.g. by secret scanners) as belonging to this service.
+const API_KEY_PREFIX: &str = "vhb_";
+
+const SHA256_LEN: usize = 32;
+
+fn hex_decode_sha256(hex: &str) -> anyhow::Result<[u8; SHA256_LEN]> {
+    HEXLOWER_PERMISSIVE
+        .decode(hex.as_bytes())
+        .with_context(|| format!("invalid hex in {hex:?}"))?
+        .try_into()
+        .map_err(|v: Vec<u8>| anyhow::anyhow!("expected {SHA256_LEN} bytes, got {}", v.len()))
+}
+
+/// One accepted API key, stored as its SHA-256 digest so the keys file
+/// never contains the secret itself. The name identifies the key in
+/// logs and makes revocation (deleting its line) practical.
+struct ApiKeyEntry {
+    digest: [u8; SHA256_LEN],
+    name: String,
+}
+
+impl ApiKeyEntry {
+    /// Parse a `sha256:<hex> [name]` line; empty lines and `#` comments
+    /// yield `None`.
+    fn parse_line(line: &str) -> anyhow::Result<Option<Self>> {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            return Ok(None);
+        }
+        let mut fields = line.split_whitespace();
+        let hex = fields
+            .next()
+            .expect("non-empty line has a first field")
+            .strip_prefix("sha256:")
+            .context("API key line must start with 'sha256:'")?;
+        let digest = hex_decode_sha256(hex)?;
+        let name = fields.next().unwrap_or(&hex[..8]).to_string();
+        Ok(Some(Self { digest, name }))
+    }
+}
+
+/// One tracked API keys file: its mtime when last read and the entries it
+/// contained (mirrors `AuthKeysFile` in `auth_ssh`).
+struct ApiKeysFile {
+    mtime: SystemTime,
+    entries: Vec<ApiKeyEntry>,
+}
+
+impl ApiKeysFile {
+    /// Stat `path`, folding `NotFound` into `Ok(None)` so missing files are
+    /// treated as "tracked absence" rather than a hard error.
+    fn stat_mtime(path: &str) -> std::io::Result<Option<SystemTime>> {
+        match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(m) => Ok(Some(m)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Parse an API keys file. Malformed lines are skipped with a warning:
+    /// a bad line can only reduce access, and dropping the whole file on
+    /// one typo would lock out every other key.
+    fn parse_keys(path: &str) -> anyhow::Result<Vec<ApiKeyEntry>> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read API keys from {path}"))?;
+        let mut entries = Vec::new();
+        for (nr, line) in content.lines().enumerate() {
+            match ApiKeyEntry::parse_line(line) {
+                Ok(Some(entry)) => entries.push(entry),
+                Ok(None) => {}
+                Err(e) => warn!("{path}:{}: skipping API key line: {e:#}", nr + 1),
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Stat and parse `path`. Returns `Ok(None)` if the file does not
+    /// exist yet (it will be picked up by `maybe_reload` once it appears).
+    fn load(path: &str) -> anyhow::Result<Option<Self>> {
+        let mtime = match Self::stat_mtime(path) {
+            Ok(Some(m)) => m,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(format!("failed to stat {path}")));
+            }
+        };
+        let entries = Self::parse_keys(path)?;
+        Ok(Some(Self { mtime, entries }))
+    }
+}
+
+struct ApiKeyCache {
+    files: HashMap<String, ApiKeysFile>,
+}
+
+impl ApiKeyCache {
+    /// Initial load of all tracked paths. Files that do not (yet) exist
+    /// are silently skipped; they will be picked up by `reload` once
+    /// they appear. Read errors propagate (startup should fail loud).
+    fn load_all(paths: &[String]) -> anyhow::Result<Self> {
+        let mut files = HashMap::new();
+        for path in paths {
+            match ApiKeysFile::load(path)? {
+                Some(f) => {
+                    files.insert(path.clone(), f);
+                }
+                None => info!("API keys file {path} does not exist yet, skipping"),
+            }
+        }
+        Ok(Self { files })
+    }
+
+    fn key_count(&self) -> usize {
+        self.files.values().map(|f| f.entries.len()).sum()
+    }
+
+    /// Find the name of the API key matching `digest`. Comparing digests in
+    /// constant time is cheap insurance even though a timing side channel
+    /// on a digest does not reveal the key itself.
+    fn lookup(&self, digest: &[u8; SHA256_LEN]) -> Option<String> {
+        self.files
+            .values()
+            .flat_map(|f| &f.entries)
+            .find(|e| openssl::memcmp::eq(&e.digest, digest))
+            .map(|e| e.name.clone())
+    }
+
+    /// Ok(true) if any `path` in `paths` has an mtime that differs from
+    /// what this cache has recorded (including "file now exists" and
+    /// "file now gone").
+    fn any_mtime_changed(&self, paths: &[String]) -> Result<bool, (String, std::io::Error)> {
+        for path in paths {
+            let now = ApiKeysFile::stat_mtime(path).map_err(|e| (path.clone(), e))?;
+            let cached = self.files.get(path).map(|f| f.mtime);
+            if now != cached {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// If any tracked path has changed on disk, re-read it; transient
+    /// stat errors are logged and the cache is left untouched (retried
+    /// on the next call).
+    fn maybe_reload(&mut self, paths: &[String]) {
+        match self.any_mtime_changed(paths) {
+            Ok(false) => {}
+            Ok(true) => self.reload(paths),
+            Err((path, e)) => {
+                warn!("cannot stat {path}: {e}, skipping reload (keeping cached API keys)");
+            }
+        }
+    }
+
+    fn reload(&mut self, paths: &[String]) {
+        let mut new_files = HashMap::new();
+        for path in paths {
+            let Ok(Some(mtime)) = ApiKeysFile::stat_mtime(path) else {
+                continue; // file is gone or unreadable; drop its cached keys
+            };
+            let entries = match ApiKeysFile::parse_keys(path) {
+                Ok(entries) => {
+                    info!(
+                        "reloaded {count} API key(s) from {path} (file changed)",
+                        count = entries.len(),
+                    );
+                    entries
+                }
+                Err(e) => {
+                    warn!("failed to reload {path}: {e:#}, skipping this source");
+                    Vec::new()
+                }
+            };
+            new_files.insert(path.clone(), ApiKeysFile { mtime, entries });
+        }
+
+        self.files = new_files;
+        if self.key_count() == 0 {
+            warn!("all API key sources are empty, API key auth will reject all requests");
+        }
+    }
+}
+
+pub(crate) struct ApiKeyAuthenticator {
+    paths: Vec<String>,
+    keys: Mutex<ApiKeyCache>,
+}
+
+impl ApiKeyAuthenticator {
+    pub(crate) fn new(paths: Vec<String>) -> anyhow::Result<Self> {
+        let cache = ApiKeyCache::load_all(&paths)?;
+        Ok(Self {
+            paths,
+            keys: Mutex::new(cache),
+        })
+    }
+
+    pub(crate) fn key_count(&self) -> usize {
+        self.keys.lock().unwrap().key_count()
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuthenticator")
+            .field("paths", &self.paths)
+            .field("key_count", &self.key_count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Authenticator for ApiKeyAuthenticator {
+    fn check_request(
+        &self,
+        method: &str,
+        path: &str,
+        auth_header: Option<&str>,
+        _nonce: Option<&str>,
+        _channel_binding: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let mut keys = self.keys.lock().unwrap();
+        keys.maybe_reload(&self.paths);
+
+        let auth_header = auth_header.context("missing Authorization header")?;
+        let key = auth_header
+            .strip_prefix("Bearer ")
+            .context("Authorization header must start with 'Bearer '")?;
+        let digest = openssl::sha::sha256(key.as_bytes());
+        let name = keys.lookup(&digest).context("unknown API key")?;
+
+        info!("api-key auth OK: {method} {path} key={name}");
+        Ok(())
+    }
+}
+
+/// Create an API key authenticator, or `None` when API key auth is not
+/// configured. An explicit `--api-keys` flag always enables it (even for a
+/// not-yet-existing file, which is picked up on reload); the well-known
+/// locations enable it only when present, so a bridge without any API key
+/// configuration does not grow an authenticator that rejects everything.
+pub(crate) fn create_api_key_authenticator(
+    cli_api_keys: Option<String>,
+    creds_dir: Option<&std::path::Path>,
+    root: &std::path::Path,
+) -> anyhow::Result<Option<ApiKeyAuthenticator>> {
+    let paths: Vec<String> = if let Some(cli_path) = cli_api_keys {
+        vec![cli_path]
+    } else {
+        let mut paths = vec![
+            root.join("etc/varlink-httpd/api-keys")
+                .to_string_lossy()
+                .to_string(),
+        ];
+        if let Some(d) = creds_dir {
+            paths.push(d.join("api-keys").to_string_lossy().to_string());
+        }
+        paths.retain(|p| std::path::Path::new(p).exists());
+        if paths.is_empty() {
+            return Ok(None);
+        }
+        paths
+    };
+
+    let api_key_auth = ApiKeyAuthenticator::new(paths.clone())?;
+    if api_key_auth.key_count() == 0 {
+        warn!(
+            "no API keys in {}; API key auth will reject all requests until keys appear",
+            paths.join(", "),
+        );
+    }
+    info!(
+        "Authenticator: adding API keys ({count} key(s) from {sources})",
+        count = api_key_auth.key_count(),
+        sources = paths.join(", "),
+    );
+    Ok(Some(api_key_auth))
+}
+
+#[derive(Debug)]
+pub(crate) struct GenApiKey {
+    pub name: Option<String>,
+    pub output: Option<String>,
+}
+
+fn default_api_keys_path() -> String {
+    if rustix::process::getuid().is_root() {
+        return "/etc/varlink-httpd/api-keys".to_string();
+    }
+    let config_dir = std::env::var_os("XDG_CONFIG_HOME").map_or_else(
+        || {
+            let home = std::env::var_os("HOME").unwrap_or_else(|| "/root".into());
+            std::path::Path::new(&home).join(".config")
+        },
+        std::path::PathBuf::from,
+    );
+    config_dir
+        .join("varlink-httpd/api-keys")
+        .to_string_lossy()
+        .into_owned()
+}
+
+pub(crate) fn generate_api_key() -> String {
+    let mut buf = [0u8; 32];
+    openssl::rand::rand_bytes(&mut buf).expect("openssl PRNG failed");
+    format!("{API_KEY_PREFIX}{}", HEXLOWER.encode(&buf))
+}
+
+/// Append the hash line for `key` to the API keys file at `path`,
+/// returning the name it was stored under.
+pub(crate) fn append_api_key(
+    path: &std::path::Path,
+    key: &str,
+    name: Option<&str>,
+) -> anyhow::Result<String> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let hex = HEXLOWER.encode(&openssl::sha::sha256(key.as_bytes()));
+    let name = name.unwrap_or(&hex[..8]);
+    // The name is a whitespace-separated field on the key line.
+    if name.chars().any(char::is_whitespace) {
+        bail!("API key name must not contain whitespace: {name:?}");
+    }
+
+    let parent = path
+        .parent()
+        .with_context(|| format!("cannot determine parent directory of {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    // 0600: the file only holds hashes, but there is no reason to share it.
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(f, "sha256:{hex} {name}")
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(name.to_string())
+}
+
+pub(crate) fn run_gen_api_key(cmd: GenApiKey) -> anyhow::Result<()> {
+    let output_path = cmd.output.unwrap_or_else(default_api_keys_path);
+    let key = generate_api_key();
+    let name = append_api_key(
+        std::path::Path::new(&output_path),
+        &key,
+        cmd.name.as_deref(),
+    )?;
+
+    // The key itself goes to stdout (and nowhere else) so that
+    // `API_KEY=$(varlink-httpd gen-api-key)` works; only its hash is stored.
+    println!("{key}");
+    eprintln!("Appended hash of API key '{name}' to {output_path}, run with:");
+    if output_path == "/etc/varlink-httpd/api-keys" {
+        eprintln!("  varlink-httpd");
+    } else {
+        eprintln!("  varlink-httpd --api-keys={output_path}");
+    }
+    Ok(())
+}

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -30,6 +30,7 @@ use tokio::signal;
 use tokio_vsock::VsockListener;
 use zlink::varlink_service::Proxy;
 
+mod auth_api_key;
 #[cfg(feature = "sshauth")]
 mod auth_ssh;
 #[cfg(feature = "sshauth")]
@@ -1059,6 +1060,7 @@ enum Command {
     Bridge(BridgeCli),
     #[cfg(feature = "sshauth")]
     ImportSsh(import_ssh::ImportSsh),
+    GenApiKey(auth_api_key::GenApiKey),
 }
 
 use varlink_http_bridge::DEFAULT_PORT;
@@ -1144,6 +1146,7 @@ struct BridgeCli {
     key: Option<String>,
     trust: Option<String>,
     authorized_keys: Option<String>,
+    api_keys: Option<String>,
     insecure: bool,
 }
 
@@ -1153,12 +1156,14 @@ fn print_help() {
         indoc::formatdoc! {"
         Usage: varlink-httpd [bridge] [OPTIONS] [VARLINK_SOCKETS_PATH]
                varlink-httpd import-ssh SOURCE [OUTPUT]
+               varlink-httpd gen-api-key [--name=NAME] [OUTPUT]
 
         A HTTP/WebSocket daemon for varlink sockets.
 
         Subcommands:
           bridge (default)                  start the HTTP/WebSocket server
           import-ssh SOURCE [OUTPUT]        download SSH authorized keys from a URL
+          gen-api-key [OUTPUT]              generate an API key and store its hash
 
         Bridge options:
           VARLINK_SOCKETS_PATH              directory of sockets or a single socket
@@ -1170,6 +1175,7 @@ fn print_help() {
           --key=PATH                        TLS private key PEM file
           --trust=PATH                      CA certificate PEM for client verification (mTLS)
           --authorized-keys=PATH            authorized SSH public keys file
+          --api-keys=PATH                   API key hashes file (see gen-api-key)
           --insecure                        run without any authentication (DANGEROUS)
           --help                            display this help and exit
     "}
@@ -1201,6 +1207,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     let mut key = None;
     let mut trust = None;
     let mut authorized_keys = None;
+    let mut api_keys = None;
     let mut insecure = false;
     let mut got_positional = false;
 
@@ -1212,6 +1219,7 @@ fn parse_cli() -> anyhow::Result<Command> {
             Long("key") => key = Some(parser.value()?.parse()?),
             Long("trust") => trust = Some(parser.value()?.parse()?),
             Long("authorized-keys") => authorized_keys = Some(parser.value()?.parse()?),
+            Long("api-keys") => api_keys = Some(parser.value()?.parse()?),
             Long("insecure") => insecure = true,
             Long("help") => {
                 print_help();
@@ -1220,6 +1228,9 @@ fn parse_cli() -> anyhow::Result<Command> {
             #[cfg(feature = "sshauth")]
             Value(val) if !got_positional && val == "import-ssh" => {
                 return parse_import_ssh_args(&mut parser);
+            }
+            Value(val) if !got_positional && val == "gen-api-key" => {
+                return parse_gen_api_key_args(&mut parser);
             }
             Value(val) if !got_positional && val == "bridge" => {
                 // explicit "bridge" subcommand, just consume the keyword
@@ -1248,8 +1259,47 @@ fn parse_cli() -> anyhow::Result<Command> {
         key,
         trust,
         authorized_keys,
+        api_keys,
         insecure,
     }))
+}
+
+fn print_gen_api_key_help() {
+    eprint!(indoc::indoc! {"
+        Usage: varlink-httpd gen-api-key [--name=NAME] [OUTPUT]
+
+        Generate a random API key and append its SHA-256 hash to an
+        API keys file. The key itself is printed to stdout exactly once
+        and stored nowhere.
+
+        Positional arguments:
+          OUTPUT       API keys file path (default: auto-detected)
+
+        Options:
+          --name=NAME  name for the key in the file (default: derived from hash)
+          --help       display this help and exit
+    "});
+}
+
+fn parse_gen_api_key_args(parser: &mut lexopt::Parser) -> anyhow::Result<Command> {
+    use lexopt::prelude::*;
+
+    let mut name = None;
+    let mut output = None;
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Long("name") => name = Some(parser.value()?.parse()?),
+            Long("help") => {
+                print_gen_api_key_help();
+                std::process::exit(0);
+            }
+            Value(val) if output.is_none() => output = Some(val.parse()?),
+            _ => return Err(arg.unexpected().into()),
+        }
+    }
+
+    Ok(Command::GenApiKey(auth_api_key::GenApiKey { name, output }))
 }
 
 #[cfg(feature = "sshauth")]
@@ -1286,6 +1336,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = match command {
         #[cfg(feature = "sshauth")]
         Command::ImportSsh(cmd) => return import_ssh::run(cmd),
+        Command::GenApiKey(cmd) => return auth_api_key::run_gen_api_key(cmd),
         Command::Bridge(cli) => cli,
     };
 
@@ -1303,6 +1354,16 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut authenticators: Vec<Box<dyn Authenticator>> = Vec::new();
+
+    // API key auth first: a hash lookup is much cheaper than an SSH
+    // signature verification and the middleware tries them in order.
+    if let Some(api_key_auth) = auth_api_key::create_api_key_authenticator(
+        cli.api_keys,
+        creds_dir.as_deref(),
+        std::path::Path::new("/"),
+    )? {
+        authenticators.push(Box::new(api_key_auth));
+    }
 
     #[cfg(feature = "sshauth")]
     {
@@ -1330,7 +1391,7 @@ async fn main() -> anyhow::Result<()> {
         } else {
             #[cfg(not(feature = "sshauth"))]
             bail!(
-                "no authentication configured: build with 'sshauth' feature, use --trust=, or --insecure"
+                "no authentication configured: use --api-keys= (see gen-api-key), --trust=, --insecure, or build with the 'sshauth' feature"
             );
         }
     }

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1942,3 +1942,181 @@ mod sshauth_tests {
         assert_hostname_reply(&output);
     }
 } // mod sshauth_tests
+
+// --- API key auth tests ---
+
+mod apikey_tests {
+    use super::*;
+    use crate::auth_api_key::{ApiKeyAuthenticator, append_api_key, create_api_key_authenticator};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    /// Create a fake rootdir with an `etc/varlink-httpd/api-keys` file.
+    fn make_test_rootdir_with_api_key_lines(lines: &[&str]) -> tempfile::TempDir {
+        use std::io::Write;
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("etc/varlink-httpd");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut f = std::fs::File::create(dir.join("api-keys")).unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+        root
+    }
+
+    /// Set up an API key authenticator that accepts one freshly generated key.
+    ///
+    /// Returns the authenticator, the key, and the API keys file path.
+    fn make_test_api_key_auth() -> (ApiKeyAuthenticator, String, std::path::PathBuf) {
+        let root = make_test_rootdir_with_api_key_lines(&[]);
+        let keys_path = root.path().join("etc/varlink-httpd/api-keys");
+        let key = crate::auth_api_key::generate_api_key();
+        append_api_key(&keys_path, &key, Some("testkey")).unwrap();
+        let auth = create_api_key_authenticator(None, None, root.path())
+            .unwrap()
+            .expect("API keys file exists, authenticator must be created");
+        std::mem::forget(root);
+        (auth, key, keys_path)
+    }
+
+    fn make_api_key_test_router(authenticators: Vec<Box<dyn Authenticator>>) -> Router {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.keep();
+        create_router(path.to_str().unwrap(), authenticators).unwrap()
+    }
+
+    #[test]
+    fn test_api_key_auth_accepts_valid_key() {
+        let (auth, key, _) = make_test_api_key_auth();
+        let header = format!("Bearer {key}");
+        auth.check_request("GET", "/sockets", Some(&header), None, None)
+            .expect("valid API key must be accepted");
+    }
+
+    #[test]
+    fn test_api_key_auth_rejects_unknown_key() {
+        let (auth, _, _) = make_test_api_key_auth();
+        let result = auth.check_request("GET", "/sockets", Some("Bearer vhb_bogus"), None, None);
+        assert!(result.unwrap_err().to_string().contains("unknown API key"));
+    }
+
+    #[test]
+    fn test_api_key_auth_rejects_missing_header() {
+        let (auth, _, _) = make_test_api_key_auth();
+        let result = auth.check_request("GET", "/sockets", None, None, None);
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing Authorization header")
+        );
+    }
+
+    #[test]
+    fn test_api_key_auth_rejects_non_bearer_scheme() {
+        let (auth, _, _) = make_test_api_key_auth();
+        let result = auth.check_request("GET", "/sockets", Some("Basic dXNlcjpwdw=="), None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_api_key_auth_skips_garbage_lines() {
+        let root = make_test_rootdir_with_api_key_lines(&[
+            "# a comment",
+            "",
+            "not-an-api-key-line",
+            "sha256:tooshort",
+            &format!("sha256:{} named", "a".repeat(64)),
+            &"b".repeat(64), // missing sha256: prefix
+        ]);
+        let auth = create_api_key_authenticator(None, None, root.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(auth.key_count(), 1);
+    }
+
+    #[test]
+    fn test_api_key_auth_not_configured_returns_none() {
+        let root = tempfile::tempdir().unwrap();
+        let auth = create_api_key_authenticator(None, None, root.path()).unwrap();
+        assert!(
+            auth.is_none(),
+            "no API keys file anywhere: no authenticator"
+        );
+    }
+
+    #[test]
+    fn test_api_key_auth_explicit_flag_allows_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_path = dir.path().join("api-keys");
+        let auth = create_api_key_authenticator(
+            Some(keys_path.to_string_lossy().into_owned()),
+            None,
+            std::path::Path::new("/nonexistent"),
+        )
+        .unwrap()
+        .expect("explicit --api-keys must always enable the authenticator");
+        assert_eq!(auth.key_count(), 0);
+
+        // The file appearing later is picked up without a restart.
+        let key = crate::auth_api_key::generate_api_key();
+        append_api_key(&keys_path, &key, None).unwrap();
+        let header = format!("Bearer {key}");
+        auth.check_request("GET", "/sockets", Some(&header), None, None)
+            .expect("API key from newly appeared file must be accepted");
+    }
+
+    #[test]
+    fn test_api_key_auth_drops_keys_when_file_removed() {
+        let (auth, key, keys_path) = make_test_api_key_auth();
+        std::fs::remove_file(&keys_path).unwrap();
+        let header = format!("Bearer {key}");
+        let result = auth.check_request("GET", "/sockets", Some(&header), None, None);
+        assert!(
+            result.is_err(),
+            "API key from removed file must be rejected"
+        );
+        assert_eq!(auth.key_count(), 0);
+    }
+
+    #[test]
+    fn test_gen_api_key_default_name_is_hash_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_path = dir.path().join("api-keys");
+        let name = append_api_key(&keys_path, "vhb_test", None).unwrap();
+        assert_eq!(name.len(), 8);
+        let content = std::fs::read_to_string(&keys_path).unwrap();
+        assert!(content.contains(&name));
+    }
+
+    #[test]
+    fn test_gen_api_key_rejects_whitespace_in_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_path = dir.path().join("api-keys");
+        assert!(append_api_key(&keys_path, "vhb_test", Some("bad name")).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_api_key_auth_via_router() {
+        let (auth, key, _) = make_test_api_key_auth();
+        let app = make_api_key_test_router(vec![Box::new(auth)]);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/sockets")
+                    .header("Authorization", format!("Bearer {key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app
+            .oneshot(Request::get("/sockets").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+} // mod apikey_tests

--- a/src/bin/varlinkctl-http/api_key_client.rs
+++ b/src/bin/varlinkctl-http/api_key_client.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Client-side API key support: the key is obtained out of band (see
+//! `varlink-httpd gen-api-key`) and simply attached as
+//! `Authorization: Bearer <key>`.
+
+use anyhow::{Context, Result};
+use futures_util::future::BoxFuture;
+use log::debug;
+use tokio_tungstenite::tungstenite;
+
+use crate::client_auth::ClientAuth;
+
+/// Environment variable carrying the API key itself (not a path, unlike
+/// `VARLINK_SSH_KEY`); surrounding whitespace is trimmed so a key piped in
+/// with a trailing newline still works.
+const VARLINK_API_KEY_ENV: &str = "VARLINK_API_KEY";
+
+pub(crate) struct ApiKeyBearer;
+
+impl ClientAuth for ApiKeyBearer {
+    fn name(&self) -> &'static str {
+        "API key auth (VARLINK_API_KEY)"
+    }
+
+    fn configured(&self) -> bool {
+        std::env::var_os(VARLINK_API_KEY_ENV).is_some()
+    }
+
+    fn add_credentials<'a>(
+        &'a self,
+        request: &'a mut tungstenite::http::Request<()>,
+        _tls_channel_binding: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<bool>> {
+        Box::pin(async move {
+            let Ok(api_key) = std::env::var(VARLINK_API_KEY_ENV) else {
+                return Ok(false);
+            };
+            let api_key = api_key.trim();
+            if api_key.is_empty() {
+                return Ok(false);
+            }
+
+            request.headers_mut().insert(
+                "Authorization",
+                format!("Bearer {api_key}")
+                    .parse()
+                    .context("VARLINK_API_KEY is not a valid HTTP header value")?,
+            );
+            debug!("API key auth: attached bearer key from {VARLINK_API_KEY_ENV}");
+            Ok(true)
+        })
+    }
+}

--- a/src/bin/varlinkctl-http/client_auth.rs
+++ b/src/bin/varlinkctl-http/client_auth.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Auth method selection for the WebSocket upgrade request: the first method
+//! in `methods()` that adds its credentials wins. Selection, conflict
+//! warnings, reduced-build diagnostics and rejection hints are generic, so a
+//! new method (JWT, `DPoP`, RFC 9421) only adds a `ClientAuth` impl and an
+//! entry.
+
+use anyhow::Result;
+use futures_util::future::BoxFuture;
+use log::{debug, warn};
+use tokio_tungstenite::tungstenite;
+
+pub(crate) trait ClientAuth {
+    /// Short name for logs and error hints.
+    fn name(&self) -> &'static str;
+
+    /// Explicit user intent (its env var is set), never ambient state like
+    /// `SSH_AUTH_SOCK`: this only drives conflict warnings, which must not
+    /// fire on every desktop that happens to run an ssh-agent.
+    fn configured(&self) -> bool;
+
+    /// Add this method's credentials to the request; `Ok(false)` when not
+    /// applicable (e.g. its env var is unset). Boxed so the trait stays
+    /// object-safe.
+    fn add_credentials<'a>(
+        &'a self,
+        request: &'a mut tungstenite::http::Request<()>,
+        tls_channel_binding: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<bool>>;
+
+    /// Appended to the connect error when the server rejected the request.
+    fn rejected_hint(&self) -> String {
+        format!(
+            " ({} was rejected by the server; other auth methods were skipped)",
+            self.name()
+        )
+    }
+}
+
+/// Always compiled, so a credential whose method is compiled out warns
+/// instead of being silently ignored.
+const METHOD_FEATURES: &[(&str, &str, bool)] =
+    &[("VARLINK_SSH_KEY", "sshauth", cfg!(feature = "sshauth"))];
+
+/// In precedence order.
+fn methods() -> Vec<&'static dyn ClientAuth> {
+    vec![
+        &crate::api_key_client::ApiKeyBearer,
+        #[cfg(feature = "sshauth")]
+        &crate::sshauth_client::SshSignature,
+    ]
+}
+
+/// Returns the chosen method so the connect error can carry its rejection hint.
+pub(crate) async fn select_auth_method(
+    request: &mut tungstenite::http::Request<()>,
+    tls_channel_binding: Option<&str>,
+) -> Result<Option<&'static dyn ClientAuth>> {
+    for (env, feature, enabled) in METHOD_FEATURES {
+        if !enabled && std::env::var_os(env).is_some() {
+            warn!("{env} is set but this build lacks the '{feature}' feature; ignoring it");
+        }
+    }
+
+    let methods = methods();
+    for (i, method) in methods.iter().enumerate() {
+        if !method.add_credentials(request, tls_channel_binding).await? {
+            continue;
+        }
+        debug!("auth: using {}", method.name());
+        for other in &methods[i + 1..] {
+            if other.configured() {
+                warn!(
+                    "{} takes precedence; ignoring {}",
+                    method.name(),
+                    other.name()
+                );
+            }
+        }
+        return Ok(Some(*method));
+    }
+    Ok(None)
+}

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -15,18 +15,10 @@ use tokio::signal::unix::{SignalKind, signal};
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::{self, Message};
 
+mod api_key_client;
+mod client_auth;
 #[cfg(feature = "sshauth")]
 mod sshauth_client;
-
-#[cfg(feature = "sshauth")]
-use sshauth_client::maybe_add_auth_headers;
-#[cfg(not(feature = "sshauth"))]
-async fn maybe_add_auth_headers(
-    _request: &mut tungstenite::http::Request<()>,
-    _tls_channel_binding: Option<&str>,
-) -> Result<()> {
-    Ok(())
-}
 
 /// One object-safe type for all transport combinations
 /// (TCP/vsock, with/without TLS).
@@ -214,25 +206,36 @@ async fn connect_ws(url: &str) -> Result<Ws> {
     let mut request = ws_url
         .into_client_request()
         .context("building WS request")?;
-    maybe_add_auth_headers(&mut request, tls_channel_binding.as_deref()).await?;
+    let chosen_auth =
+        client_auth::select_auth_method(&mut request, tls_channel_binding.as_deref()).await?;
 
     let (ws, _) = tokio_tungstenite::client_async(request, stream)
         .await
         .map_err(|e| {
-            let http_detail = match &e {
-                tungstenite::Error::Http(resp) => match resp_body_text(resp) {
-                    Some(body) => format!(": HTTP {}: {body}", resp.status()),
-                    None => format!(": HTTP {}", resp.status()),
-                },
-                _ => String::new(),
+            let (http_detail, auth_hint) = match &e {
+                tungstenite::Error::Http(resp) => {
+                    let detail = match resp_body_text(resp) {
+                        Some(body) => format!(": HTTP {}: {body}", resp.status()),
+                        None => format!(": HTTP {}", resp.status()),
+                    };
+                    let hint = match chosen_auth {
+                        Some(method) if matches!(resp.status().as_u16(), 401 | 403) => {
+                            method.rejected_hint()
+                        }
+                        _ => String::new(),
+                    };
+                    (detail, hint)
+                }
+                _ => (String::new(), String::new()),
             };
             let tls_hint = if is_tls {
                 " (check client cert if server requires mTLS)"
             } else {
                 ""
             };
-            anyhow::Error::new(e)
-                .context(format!("WebSocket handshake failed{http_detail}{tls_hint}"))
+            anyhow::Error::new(e).context(format!(
+                "WebSocket handshake failed{http_detail}{auth_hint}{tls_hint}"
+            ))
         })?;
     debug!("WebSocket established");
     Ok(ws)

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 use anyhow::{Context, Result, bail};
+use futures_util::future::BoxFuture;
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
 use varlink_http_bridge::SSHAUTH_MAGIC_PREFIX;
+
+use crate::client_auth::ClientAuth;
 
 struct Signer {
     builder: sshauth::signer::TokenSignerBuilder,
@@ -13,32 +16,48 @@ struct Signer {
     source: String,
 }
 
-pub(crate) async fn maybe_add_auth_headers(
-    request: &mut tungstenite::http::Request<()>,
-    tls_channel_binding: Option<&str>,
-) -> Result<()> {
-    // to_string: ends the borrow of `request` before headers_mut() below
-    let path_and_query = request
-        .uri()
-        .path_and_query()
-        .map_or(request.uri().path(), |pq| pq.as_str())
-        .to_string();
+pub(crate) struct SshSignature;
 
-    let (bearer, nonce) = match build_auth_token("GET", &path_and_query, tls_channel_binding).await
-    {
-        Ok(Some((bearer, nonce))) => (bearer, nonce),
-        Ok(None) => return Ok(()),
-        Err(e) => return Err(e).context("auth token generation failed"),
-    };
-    request.headers_mut().insert(
-        "Authorization",
-        bearer.parse().context("invalid auth header value")?,
-    );
-    request.headers_mut().insert(
-        varlink_http_bridge::SSHAUTH_NONCE_HEADER,
-        nonce.parse().context("invalid nonce header value")?,
-    );
-    Ok(())
+impl ClientAuth for SshSignature {
+    fn name(&self) -> &'static str {
+        "SSH signature auth (VARLINK_SSH_KEY or ssh-agent)"
+    }
+
+    fn configured(&self) -> bool {
+        std::env::var_os("VARLINK_SSH_KEY").is_some()
+    }
+
+    /// Sign the request with an SSH key; `Ok(false)` when no key is available.
+    fn add_credentials<'a>(
+        &'a self,
+        request: &'a mut tungstenite::http::Request<()>,
+        tls_channel_binding: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<bool>> {
+        Box::pin(async move {
+            // to_string: ends the borrow of `request` before headers_mut() below
+            let path_and_query = request
+                .uri()
+                .path_and_query()
+                .map_or(request.uri().path(), |pq| pq.as_str())
+                .to_string();
+
+            let (bearer, nonce) =
+                match build_auth_token("GET", &path_and_query, tls_channel_binding).await {
+                    Ok(Some((bearer, nonce))) => (bearer, nonce),
+                    Ok(None) => return Ok(false),
+                    Err(e) => return Err(e).context("auth token generation failed"),
+                };
+            request.headers_mut().insert(
+                "Authorization",
+                bearer.parse().context("invalid auth header value")?,
+            );
+            request.headers_mut().insert(
+                varlink_http_bridge::SSHAUTH_NONCE_HEADER,
+                nonce.parse().context("invalid nonce header value")?,
+            );
+            Ok(true)
+        })
+    }
 }
 
 /// Build an SSH auth token for the given HTTP method and path.


### PR DESCRIPTION
This is the most simple form of authentication. Plain api keys that can be used trivially with e.g. curl to run authenticated calls against varlink-httpd.