### PR TITLE
sysconf: add systemd credentials/config discovery

### DIFF
--- a/src/bin/varlink-httpd/import_ssh.rs
+++ b/src/bin/varlink-httpd/import_ssh.rs
@@ -10,8 +10,8 @@ pub(crate) struct ImportSsh {
 }
 
 fn default_authorized_keys_path() -> String {
-    if let Some(creds_dir) = std::env::var_os("CREDENTIALS_DIRECTORY") {
-        return std::path::Path::new(&creds_dir)
+    if let Some(creds_dir) = varlink_http_bridge::sysconf::CredentialsLoader::path_from_env() {
+        return creds_dir
             .join("authorized_keys")
             .to_string_lossy()
             .into_owned();
@@ -62,7 +62,7 @@ pub(crate) fn run(cmd: ImportSsh) -> anyhow::Result<()> {
         "Wrote {keys_count} key(s) to {output_path}, run with:",
         keys_count = imported.keys.len()
     );
-    if std::env::var_os("CREDENTIALS_DIRECTORY").is_some() {
+    if varlink_http_bridge::sysconf::CredentialsLoader::path_from_env().is_some() {
         eprintln!("  varlink-httpd");
     } else {
         eprintln!("  varlink-httpd --authorized-keys={output_path}");

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -504,10 +504,11 @@ fn resolve_tls_acceptor(
     cli_ca: Option<String>,
     creds_dir: Option<&std::path::Path>,
 ) -> anyhow::Result<Option<openssl::ssl::SslAcceptor>> {
+    let creds = creds_dir.map(varlink_http_bridge::sysconf::CredentialsLoader::from_dir);
     let cred = |name: &str| -> Option<String> {
-        creds_dir
-            .map(|d| d.join(name))
-            .filter(|p| p.exists())
+        creds
+            .as_ref()
+            .and_then(|c| c.path(name))
             .and_then(|p| p.to_str().map(String::from))
     };
 
@@ -1289,7 +1290,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Bridge(cli) => cli,
     };
 
-    let creds_dir = std::env::var_os("CREDENTIALS_DIRECTORY").map(std::path::PathBuf::from);
+    let creds_dir = varlink_http_bridge::sysconf::CredentialsLoader::path_from_env();
 
     // Resolve mTLS: remember if trust was provided before consuming the options
     let has_mtls =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+pub mod sysconf;
+
 #[cfg(feature = "sshauth")]
 /// Namespace prefix for SSH-based authentication tokens, analogous to
 /// `ssh-keygen -Y sign -n <namespace>`.  Binds signatures to this application

--- a/src/sysconf.rs
+++ b/src/sysconf.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Locating service configuration the systemd way: credentials passed via
+//! `$CREDENTIALS_DIRECTORY` (see systemd.exec(5) / systemd.system-credentials(7)),
+//! and config files in the `/etc` > `/run` > `/usr/lib` precedence hierarchy.
+
+use std::path::{Path, PathBuf};
+
+/// Mirrors libsystemd's `CredentialsLoader`: one file per credential,
+/// filename = credential id.
+pub struct CredentialsLoader {
+    dir: PathBuf,
+}
+
+impl CredentialsLoader {
+    #[must_use]
+    pub fn path_from_env() -> Option<PathBuf> {
+        std::env::var_os("CREDENTIALS_DIRECTORY").map(PathBuf::from)
+    }
+
+    /// Loader rooted at an explicit directory (mainly for tests).
+    pub fn from_dir(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Path of credential `id`, if the file exists.
+    #[must_use]
+    pub fn path(&self, id: &str) -> Option<PathBuf> {
+        let path = self.dir.join(id);
+        path.exists().then_some(path)
+    }
+}
+
+/// Highest-precedence existing config file for `rel`, following the systemd
+/// hierarchy (`/etc` over `/run` over `/usr/lib`). `root` is `/` in
+/// production, a tempdir in tests.
+#[must_use]
+pub fn find_config(rel: &str, root: &Path) -> Option<PathBuf> {
+    ["etc", "run", "usr/lib"]
+        .into_iter()
+        .map(|base| root.join(base).join(rel))
+        .find(|path| path.exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credentials_loader_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cert"), "dummy").unwrap();
+
+        let loader = CredentialsLoader::from_dir(dir.path());
+        assert_eq!(loader.path("cert"), Some(dir.path().join("cert")));
+        assert_eq!(loader.path("missing"), None);
+    }
+
+    #[test]
+    fn test_find_config_precedence() {
+        let root = tempfile::tempdir().unwrap();
+        let rel = "varlink-httpd/api-keys";
+        let write = |base: &str| {
+            let p = root.path().join(base).join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, base).unwrap();
+            p
+        };
+
+        assert_eq!(find_config(rel, root.path()), None);
+
+        let usr = write("usr/lib");
+        assert_eq!(find_config(rel, root.path()), Some(usr));
+        let run = write("run");
+        assert_eq!(find_config(rel, root.path()), Some(run));
+        let etc = write("etc");
+        assert_eq!(find_config(rel, root.path()), Some(etc));
+    }
+}


### PR DESCRIPTION
[extraction from #66 to eventually make this smaller also useful in the coming api-keys auth branch]

Extract the $CREDENTIALS_DIRECTORY handling into a new sysconf::CredentialsLoader (mirroring libsystemd's CredentialsLoader) and use it for the TLS credential lookup and the import-ssh default output path. Also add sysconf::find_config() for the /etc > /run > /usr/lib config precedence hierarchy.

This is a prereq for the jwt-auth branch (which extends the module with scalar/list credential reading) and resolves the discovery TODO on the auth-api-keys branch.