### PR TITLE
client: make auth method selection generic

### DIFF
--- a/src/bin/varlinkctl-http/client_auth.rs
+++ b/src/bin/varlinkctl-http/client_auth.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Auth method selection for the WebSocket upgrade request: the first
+//! applicable method in `methods()` wins. Selection, conflict warnings,
+//! reduced-build diagnostics and the unauthenticated fallback are generic,
+//! so a new method (JWT, `DPoP`, RFC 9421) only adds a `ClientAuth` impl
+//! and an entry.
+
+use anyhow::Result;
+use futures_util::future::LocalBoxFuture;
+use log::{debug, warn};
+
+pub(crate) trait ClientAuth {
+    fn name(&self) -> &'static str;
+
+    /// Explicit user intent (its env var is set), never ambient state like
+    /// `SSH_AUTH_SOCK`: this only drives conflict warnings, which must not
+    /// fire on every desktop that happens to run an ssh-agent.
+    fn configured(&self) -> bool;
+
+    /// `Ok(None)` when the method is not applicable (e.g. its env var is
+    /// unset). The method drives the whole connect flow so it can retry
+    /// with several candidate credentials (one attempt per SSH key).
+    /// Boxed for object safety; non-`Send` because the binary runs a
+    /// `current_thread` runtime and rustc cannot prove the SSH retry
+    /// future `Send` anyway.
+    fn connect<'a>(&'a self, url: &'a str) -> LocalBoxFuture<'a, Result<Option<crate::Ws>>>;
+}
+
+/// Always compiled, so a credential whose method is compiled out warns
+/// instead of being silently ignored.
+const METHOD_FEATURES: &[(&str, &str, bool)] =
+    &[("VARLINK_SSH_KEY", "sshauth", cfg!(feature = "sshauth"))];
+
+/// In precedence order.
+fn methods() -> Vec<&'static dyn ClientAuth> {
+    vec![
+        #[cfg(feature = "sshauth")]
+        &crate::sshauth_client::SshSignature,
+    ]
+}
+
+pub(crate) async fn connect_ws(url: &str) -> Result<crate::Ws> {
+    for (env, feature, enabled) in METHOD_FEATURES {
+        if !enabled && std::env::var_os(env).is_some() {
+            warn!("{env} is set but this build lacks the '{feature}' feature; ignoring it");
+        }
+    }
+
+    let methods = methods();
+    for (i, method) in methods.iter().enumerate() {
+        let Some(ws) = method.connect(url).await? else {
+            continue;
+        };
+        debug!("auth: using {}", method.name());
+        for other in &methods[i + 1..] {
+            if other.configured() {
+                warn!(
+                    "{} takes precedence; ignoring {}",
+                    method.name(),
+                    other.name()
+                );
+            }
+        }
+        return Ok(ws);
+    }
+
+    // No method applicable: connect unauthenticated, the server decides.
+    let (stream, request, tcb) = crate::connect_transport(url).await?;
+    crate::ws_upgrade(request, stream, tcb.is_some()).await
+}

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::{self, Message};
 use varlink_http_bridge::TlsChannelBinding;
 
+mod client_auth;
 #[cfg(feature = "sshauth")]
 mod sshauth_client;
 
@@ -188,24 +189,6 @@ fn resp_body_text(resp: &tungstenite::http::Response<Option<Vec<u8>>>) -> Option
         .as_deref()
         .filter(|b| !b.is_empty())
         .map(|b| String::from_utf8_lossy(b).into_owned())
-}
-
-#[cfg(feature = "sshauth")]
-async fn connect_ws(url: &str) -> Result<Ws> {
-    sshauth_client::connect_with_ssh_retry(async |key| {
-        let (stream, mut request, tcb) = connect_transport(url).await?;
-        if let Some(key) = key {
-            sshauth_client::add_auth_headers(&mut request, key, tcb.as_ref()).await?;
-        }
-        ws_upgrade(request, stream, tcb.is_some()).await
-    })
-    .await
-}
-
-#[cfg(not(feature = "sshauth"))]
-async fn connect_ws(url: &str) -> Result<Ws> {
-    let (stream, request, tcb) = connect_transport(url).await?;
-    ws_upgrade(request, stream, tcb.is_some()).await
 }
 
 /// The TLS channel binding is returned so auth headers can be signed
@@ -399,7 +382,7 @@ async fn main() -> Result<()> {
     fd3.set_nonblocking(true)?;
     let fd3 = UnixStream::from_std(fd3)?;
 
-    let ws = tokio::time::timeout(CONNECT_TIMEOUT, connect_ws(&bridge_url))
+    let ws = tokio::time::timeout(CONNECT_TIMEOUT, client_auth::connect_ws(&bridge_url))
         .await
         .with_context(|| format!("timed out connecting to '{bridge_url}'"))??;
 

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -3,12 +3,15 @@
 use std::fmt;
 
 use anyhow::{Context, Result, bail};
+use futures_util::future::LocalBoxFuture;
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
 use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding};
 
+use crate::client_auth::ClientAuth;
+
 /// An SSH key that can be used for authentication.
-pub(crate) enum SshKey {
+enum SshKey {
     /// A private key read from a file (`VARLINK_SSH_KEY`).
     PrivateKey {
         path: String,
@@ -54,7 +57,7 @@ impl fmt::Display for SshKey {
 ///
 /// A signing failure is returned as a [`SigningFailed`] error so the retry
 /// loop can skip the key and move on to the next one.
-pub(crate) async fn add_auth_headers(
+async fn add_auth_headers(
     request: &mut tungstenite::http::Request<()>,
     key: &SshKey,
     tls_channel_binding: Option<&TlsChannelBinding>,
@@ -81,20 +84,42 @@ pub(crate) async fn add_auth_headers(
     Ok(())
 }
 
-/// Try connecting with each available SSH key, retrying on 401.
+pub(crate) struct SshSignature;
+
+impl ClientAuth for SshSignature {
+    fn name(&self) -> &'static str {
+        "SSH signature auth (VARLINK_SSH_KEY or ssh-agent)"
+    }
+
+    fn configured(&self) -> bool {
+        std::env::var_os("VARLINK_SSH_KEY").is_some()
+    }
+
+    fn connect<'a>(&'a self, url: &'a str) -> LocalBoxFuture<'a, Result<Option<crate::Ws>>> {
+        Box::pin(connect_with_ssh_retry(url))
+    }
+}
+
+/// Try connecting with each available SSH key, retrying on 401;
+/// `Ok(None)` when no key is available.
 ///
-/// Enumerates keys from the environment (`VARLINK_SSH_KEY` or `SSH_AUTH_SOCK`),
-/// then calls `connect` for each key. Skip keys that fail to sign or get 401.
-/// Any other error is returned immediately.
-///
-/// When no key was ever presented to the server (none available, or all of
-/// them failed to sign), `connect` is called once with `None`
-/// (unauthenticated) and the server decides whether to allow that.
-pub(crate) async fn connect_with_ssh_retry<T>(
-    connect: impl AsyncFnMut(Option<&SshKey>) -> Result<T>,
-) -> Result<T> {
+/// When keys exist but none was ever presented to the server (all
+/// failed to sign), one unauthenticated attempt is made and the
+/// server decides whether to allow that.
+async fn connect_with_ssh_retry(url: &str) -> Result<Option<crate::Ws>> {
     let keys = list_ssh_keys().await?;
-    try_each_key(&keys, connect).await
+    if keys.is_empty() {
+        return Ok(None);
+    }
+    let ws = try_each_key(&keys, async |key| {
+        let (stream, mut request, tcb) = crate::connect_transport(url).await?;
+        if let Some(key) = key {
+            add_auth_headers(&mut request, key, tcb.as_ref()).await?;
+        }
+        crate::ws_upgrade(request, stream, tcb.is_some()).await
+    })
+    .await?;
+    Ok(Some(ws))
 }
 
 /// Generic retry loop: try `connect` for each key.


### PR DESCRIPTION
[useful for #66 and the planned api-key-auth]

Extract the client auth handling into a ClientAuth trait and a generic selection mechanism that finds the first applicable method and then connects using this.

The selected ClientAuth then can do internal retries (like sshkey and 401).

The existing sshauth support is the first ClientAuth implementation. But the planned jwt-auth and api-key-auth will also use this for cleaner client auth selection.