### PR TITLE
auth: pass AuthRequest to Authenticator::check_request and channel-binding newtype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/bin/varlinkctl-http/main.rs"
 [features]
 default = ["sshauth"]
 sshauth = ["dep:ssh-key", "dep:sshauth", "dep:tempfile", "dep:ssh-key-import"]
+# never enable directly: pulled in via the self dev-dependency so that
+# test-only constructors exist in test builds but not in release builds
+test-helpers = []
 
 [dependencies]
 anyhow = "1.0.100"
@@ -60,6 +63,7 @@ tempfile = { version = "3.27", optional = true }
 ssh-key-import = { path = "crates/ssh-key-import", optional = true }
 
 [dev-dependencies]
+varlink-http-bridge = { path = ".", features = ["test-helpers"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }
 test-with = { version = "0.16", default-features = false, features = ["runtime"] }
 gethostname = "1.1.0"

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
 use crate::Authenticator;
-use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER};
+use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding};
 
 /// One tracked `authorized_keys` file: its mtime when last read and the
 /// (fingerprint -> key) map of supported keys it contained. Bundling
@@ -349,7 +349,7 @@ impl Authenticator for SshKeyAuthenticator {
         path: &str,
         auth_header: Option<&str>,
         nonce: Option<&str>,
-        tls_channel_binding: Option<&str>,
+        tls_channel_binding: Option<&TlsChannelBinding>,
     ) -> anyhow::Result<()> {
         self.authorized_keys
             .lock()
@@ -386,7 +386,7 @@ impl Authenticator for SshKeyAuthenticator {
                 // (TLS 1.3 enforced in load_tls_acceptor), so a token signed with ""
                 // will fail verification. The "" default only applies to non-TLS
                 // connections where channel binding is not relevant.
-                tls_channel_binding.unwrap_or_default(),
+                tls_channel_binding.map_or("", TlsChannelBinding::as_str),
             )
             .with_keys(&authorized_keys)
             .context("token verification failed")?;

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
-use crate::Authenticator;
+use crate::{AuthRequest, Authenticator};
 use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding};
 
 /// One tracked `authorized_keys` file: its mtime when last read and the
@@ -293,7 +293,7 @@ impl std::fmt::Debug for SshKeyAuthenticator {
 }
 
 /// Extract the replay-protection nonce from the request headers.
-pub(crate) fn extract_nonce(headers: &axum::http::HeaderMap) -> Option<String> {
+fn extract_nonce(headers: &axum::http::HeaderMap) -> Option<String> {
     headers
         .get(SSHAUTH_NONCE_HEADER)
         .and_then(|v| v.to_str().ok())
@@ -343,25 +343,17 @@ pub(crate) fn create_ssh_authenticator(
 }
 
 impl Authenticator for SshKeyAuthenticator {
-    fn check_request(
-        &self,
-        method: &str,
-        path: &str,
-        auth_header: Option<&str>,
-        nonce: Option<&str>,
-        tls_channel_binding: Option<&TlsChannelBinding>,
-    ) -> anyhow::Result<()> {
+    fn check_request(&self, request: &AuthRequest) -> anyhow::Result<()> {
         self.authorized_keys
             .lock()
             .unwrap()
             .maybe_reload(&self.paths);
 
-        let auth_header = auth_header.context("missing Authorization header")?;
-        let nonce = nonce.context("missing nonce header (x-auth-nonce)")?;
-
-        let token_str = auth_header
-            .strip_prefix("Bearer ")
-            .context("Authorization header must start with 'Bearer '")?;
+        let (method, path) = (request.method, request.path);
+        let token_str = request.bearer_token()?;
+        let nonce =
+            extract_nonce(request.headers).context("missing nonce header (x-auth-nonce)")?;
+        let nonce = nonce.as_str();
 
         let unverified_token =
             sshauth::UnverifiedToken::try_from(token_str).context("invalid token")?;
@@ -386,7 +378,9 @@ impl Authenticator for SshKeyAuthenticator {
                 // (TLS 1.3 enforced in load_tls_acceptor), so a token signed with ""
                 // will fail verification. The "" default only applies to non-TLS
                 // connections where channel binding is not relevant.
-                tls_channel_binding.map_or("", TlsChannelBinding::as_str),
+                request
+                    .tls_channel_binding
+                    .map_or("", TlsChannelBinding::as_str),
             )
             .with_keys(&authorized_keys)
             .context("token verification failed")?;

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+// Reduced-feature builds leave some shared auth plumbing unused; the
+// default build still gets full dead-code checking.
+#![cfg_attr(not(feature = "sshauth"), allow(dead_code))]
+
 use anyhow::{Context, bail};
 use async_stream::stream;
 use axum::{
@@ -37,11 +41,7 @@ mod auth_ssh;
 mod import_ssh;
 
 #[cfg(feature = "sshauth")]
-use auth_ssh::{create_ssh_authenticator, extract_nonce};
-#[cfg(not(feature = "sshauth"))]
-fn extract_nonce(_headers: &axum::http::HeaderMap) -> Option<String> {
-    None
-}
+use auth_ssh::create_ssh_authenticator;
 #[derive(Debug)]
 struct AppError {
     status: StatusCode,
@@ -528,15 +528,43 @@ fn resolve_tls_acceptor(
     }
 }
 
+/// Carries the raw headers so each auth method extracts what it needs
+/// without the trait growing a parameter per method.
+struct AuthRequest<'a> {
+    method: &'a str,
+    path: &'a str,
+    headers: &'a axum::http::HeaderMap,
+    /// From the TLS layer (RFC 9266 exporter), not a header.
+    tls_channel_binding: Option<&'a TlsChannelBinding>,
+}
+
+impl AuthRequest<'_> {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(name).and_then(|v| v.to_str().ok())
+    }
+
+    fn authorization(&self) -> Option<&str> {
+        self.header("authorization")
+    }
+
+    /// Token from `Authorization: Bearer <token>`; the scheme is
+    /// case-insensitive per RFC 7235.
+    fn bearer_token(&self) -> anyhow::Result<&str> {
+        let header = self
+            .authorization()
+            .context("missing Authorization header")?;
+        let (scheme, token) = header
+            .split_once(' ')
+            .context("Authorization header must be 'Bearer <token>'")?;
+        if !scheme.eq_ignore_ascii_case("bearer") {
+            bail!("Authorization scheme must be 'Bearer'");
+        }
+        Ok(token.trim_start_matches(' '))
+    }
+}
+
 trait Authenticator: Send + Sync {
-    fn check_request(
-        &self,
-        method: &str,
-        path: &str,
-        auth_header: Option<&str>,
-        nonce: Option<&str>,
-        channel_binding: Option<&TlsChannelBinding>,
-    ) -> anyhow::Result<()>;
+    fn check_request(&self, request: &AuthRequest) -> anyhow::Result<()>;
 }
 
 /// Authenticator that accepts every request.
@@ -552,27 +580,13 @@ struct AllowAllAuthenticator {
 }
 
 impl Authenticator for AllowAllAuthenticator {
-    fn check_request(
-        &self,
-        method: &str,
-        path: &str,
-        _auth_header: Option<&str>,
-        _nonce: Option<&str>,
-        _channel_binding: Option<&TlsChannelBinding>,
-    ) -> anyhow::Result<()> {
-        debug!("auth: allowing {method} {path} ({})", self.reason);
+    fn check_request(&self, request: &AuthRequest) -> anyhow::Result<()> {
+        debug!(
+            "auth: allowing {} {} ({})",
+            request.method, request.path, self.reason
+        );
         Ok(())
     }
-}
-
-/// Extract the Authorization header value, if present and valid UTF-8.
-fn extract_auth_header(request: &axum::http::Request<Body>) -> Option<String> {
-    request
-        .headers()
-        .get("authorization")?
-        .to_str()
-        .ok()
-        .map(String::from)
 }
 
 async fn auth_middleware(
@@ -580,38 +594,45 @@ async fn auth_middleware(
     request: axum::http::Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    let auth_header = extract_auth_header(&request);
-    let nonce = extract_nonce(request.headers());
-
     let tls_channel_binding: Option<TlsChannelBinding> = request
         .extensions()
         .get::<ConnectInfo<VarlinkConnCache>>()
         .and_then(|ci| ci.0.tls_channel_binding.clone());
 
-    let method = request.method().as_str().to_string();
-    let path = request
-        .uri()
-        .path_and_query()
-        .map_or(request.uri().path(), axum::http::uri::PathAndQuery::as_str)
-        .to_string();
+    let auth_request = AuthRequest {
+        method: request.method().as_str(),
+        path: request
+            .uri()
+            .path_and_query()
+            .map_or(request.uri().path(), axum::http::uri::PathAndQuery::as_str),
+        headers: request.headers(),
+        tls_channel_binding: tls_channel_binding.as_ref(),
+    };
 
-    debug!("auth: checking {method} {path} (nonce={nonce:?}, tls_cb={tls_channel_binding:?})");
+    debug!(
+        "auth: checking {} {} (tls_cb={:?})",
+        auth_request.method, auth_request.path, auth_request.tls_channel_binding
+    );
 
     let mut errors = Vec::new();
+    // flag instead of early return: `auth_request` borrows `request`, and
+    // next.run() needs `request` back by value
+    let mut accepted = false;
     for authenticator in state.authenticators.iter() {
-        match authenticator.check_request(
-            &method,
-            &path,
-            auth_header.as_deref(),
-            nonce.as_deref(),
-            tls_channel_binding.as_ref(),
-        ) {
+        match authenticator.check_request(&auth_request) {
             Ok(()) => {
-                debug!("auth: accepted {method} {path}");
-                return next.run(request).await;
+                debug!(
+                    "auth: accepted {} {}",
+                    auth_request.method, auth_request.path
+                );
+                accepted = true;
+                break;
             }
             Err(e) => errors.push(e.to_string()),
         }
+    }
+    if accepted {
+        return next.run(request).await;
     }
 
     let joined = if errors.is_empty() {
@@ -619,7 +640,10 @@ async fn auth_middleware(
     } else {
         errors.join("; ")
     };
-    debug!("auth: rejected {method} {path}: {joined}");
+    debug!(
+        "auth: rejected {} {}: {joined}",
+        auth_request.method, auth_request.path
+    );
     (
         StatusCode::UNAUTHORIZED,
         axum::Json(json!({"error": joined})),

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -28,6 +28,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixStream};
 use tokio::signal;
 use tokio_vsock::VsockListener;
+use varlink_http_bridge::TlsChannelBinding;
 use zlink::varlink_service::Proxy;
 
 #[cfg(feature = "sshauth")]
@@ -269,11 +270,11 @@ type VarlinkConns = HashMap<String, Arc<tokio::sync::Mutex<zlink::unix::Connecti
 #[derive(Clone)]
 struct VarlinkConnCache {
     conns: Arc<tokio::sync::Mutex<VarlinkConns>>,
-    tls_channel_binding: Option<String>,
+    tls_channel_binding: Option<TlsChannelBinding>,
 }
 
 impl VarlinkConnCache {
-    fn new(tls_channel_binding: Option<String>) -> Self {
+    fn new(tls_channel_binding: Option<TlsChannelBinding>) -> Self {
         Self {
             conns: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             tls_channel_binding,
@@ -534,7 +535,7 @@ trait Authenticator: Send + Sync {
         path: &str,
         auth_header: Option<&str>,
         nonce: Option<&str>,
-        channel_binding: Option<&str>,
+        channel_binding: Option<&TlsChannelBinding>,
     ) -> anyhow::Result<()>;
 }
 
@@ -557,7 +558,7 @@ impl Authenticator for AllowAllAuthenticator {
         path: &str,
         _auth_header: Option<&str>,
         _nonce: Option<&str>,
-        _channel_binding: Option<&str>,
+        _channel_binding: Option<&TlsChannelBinding>,
     ) -> anyhow::Result<()> {
         debug!("auth: allowing {method} {path} ({})", self.reason);
         Ok(())
@@ -582,7 +583,7 @@ async fn auth_middleware(
     let auth_header = extract_auth_header(&request);
     let nonce = extract_nonce(request.headers());
 
-    let tls_channel_binding: Option<String> = request
+    let tls_channel_binding: Option<TlsChannelBinding> = request
         .extensions()
         .get::<ConnectInfo<VarlinkConnCache>>()
         .and_then(|ci| ci.0.tls_channel_binding.clone());
@@ -603,7 +604,7 @@ async fn auth_middleware(
             &path,
             auth_header.as_deref(),
             nonce.as_deref(),
-            tls_channel_binding.as_deref(),
+            tls_channel_binding.as_ref(),
         ) {
             Ok(()) => {
                 debug!("auth: accepted {method} {path}");

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -7,6 +7,32 @@ use reqwest::Client;
 use std::os::fd::OwnedFd;
 use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message as WsMsg;
+use varlink_http_bridge::TlsChannelBinding;
+
+/// Saves each test from assembling an `AuthRequest` and its backing `HeaderMap`.
+fn check_request(
+    auth: &dyn Authenticator,
+    method: &str,
+    path: &str,
+    auth_header: Option<&str>,
+    nonce: Option<&str>,
+    tls_channel_binding: Option<&TlsChannelBinding>,
+) -> anyhow::Result<()> {
+    let mut headers = axum::http::HeaderMap::new();
+    if let Some(v) = auth_header {
+        headers.insert("authorization", v.parse().unwrap());
+    }
+    if let Some(v) = nonce {
+        // literal SSHAUTH_NONCE_HEADER, which is compiled out without "sshauth"
+        headers.insert("x-auth-nonce", v.parse().unwrap());
+    }
+    auth.check_request(&AuthRequest {
+        method,
+        path,
+        headers: &headers,
+        tls_channel_binding,
+    })
+}
 
 /// Bundles a spawned test server task with its bound address.
 /// Dropping aborts the task, so each test's server is cleaned up
@@ -1506,7 +1532,7 @@ mod sshauth_tests {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), None);
+        let result = check_request(&auth, "GET", "/sockets", Some(&header), Some(nonce), None);
         assert!(result.is_err(), "expired token should be rejected");
     }
 
@@ -1528,7 +1554,7 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), None);
+        let result = check_request(&auth, "GET", "/sockets", Some(&header), Some(nonce), None);
         assert!(result.is_err());
         assert!(
             result
@@ -1544,9 +1570,7 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "test-nonce-verify12345";
-        let cb = varlink_http_bridge::TlsChannelBinding::new(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        );
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
@@ -1556,8 +1580,15 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
-            .expect("valid ed25519 token should pass");
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        )
+        .expect("valid ed25519 token should pass");
     }
 
     #[tokio::test]
@@ -1610,14 +1641,7 @@ mod sshauth_tests {
 
     struct RejectingAuthenticator(&'static str);
     impl Authenticator for RejectingAuthenticator {
-        fn check_request(
-            &self,
-            _method: &str,
-            _path: &str,
-            _auth_header: Option<&str>,
-            _nonce: Option<&str>,
-            _channel_binding: Option<&varlink_http_bridge::TlsChannelBinding>,
-        ) -> anyhow::Result<()> {
+        fn check_request(&self, _request: &AuthRequest) -> anyhow::Result<()> {
             anyhow::bail!("{}", self.0)
         }
     }
@@ -1705,9 +1729,7 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "replay-me12345678";
-        let cb = varlink_http_bridge::TlsChannelBinding::new(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        );
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
@@ -1718,11 +1740,25 @@ mod sshauth_tests {
         let header = format!("Bearer {}", token.encode());
 
         // First use should succeed
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
-            .expect("first use of nonce should pass");
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        )
+        .expect("first use of nonce should pass");
 
         // Replay with the same nonce should fail
-        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb));
+        let result = check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        );
         assert!(result.is_err(), "replayed nonce should be rejected");
         assert!(
             result
@@ -1744,7 +1780,7 @@ mod sshauth_tests {
         let header = format!("Bearer {}", token.encode());
 
         // Without a nonce, the request should be rejected
-        let result = auth.check_request("GET", "/sockets", Some(&header), None, None);
+        let result = check_request(&auth, "GET", "/sockets", Some(&header), None, None);
         assert!(result.is_err(), "request without nonce should be rejected");
         assert!(result.unwrap_err().to_string().contains("missing nonce"));
     }
@@ -1756,9 +1792,7 @@ mod sshauth_tests {
 
         let nonce = "cb-mismatch-test12345";
         let cb_signer = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-        let cb_verifier = varlink_http_bridge::TlsChannelBinding::new(
-            "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
-        );
+        let cb_verifier = TlsChannelBinding::new("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=");
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
@@ -1768,7 +1802,8 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request(
+        let result = check_request(
+            &auth,
             "GET",
             "/sockets",
             Some(&header),
@@ -1787,9 +1822,7 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "cb-match-test-123456";
-        let cb = varlink_http_bridge::TlsChannelBinding::new(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        );
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
@@ -1799,8 +1832,15 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
-            .expect("matching channel binding should pass");
+        check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        )
+        .expect("matching channel binding should pass");
     }
 
     #[test]

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1544,17 +1544,19 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "test-nonce-verify12345";
-        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let cb = varlink_http_bridge::TlsChannelBinding::new(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
             .action("nonce", nonce)
-            .action("tls-channel-binding", cb);
+            .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
             .expect("valid ed25519 token should pass");
     }
 
@@ -1614,7 +1616,7 @@ mod sshauth_tests {
             _path: &str,
             _auth_header: Option<&str>,
             _nonce: Option<&str>,
-            _channel_binding: Option<&str>,
+            _channel_binding: Option<&varlink_http_bridge::TlsChannelBinding>,
         ) -> anyhow::Result<()> {
             anyhow::bail!("{}", self.0)
         }
@@ -1703,22 +1705,24 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "replay-me12345678";
-        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let cb = varlink_http_bridge::TlsChannelBinding::new(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
             .action("nonce", nonce)
-            .action("tls-channel-binding", cb);
+            .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
         let header = format!("Bearer {}", token.encode());
 
         // First use should succeed
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
             .expect("first use of nonce should pass");
 
         // Replay with the same nonce should fail
-        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb));
+        let result = auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb));
         assert!(result.is_err(), "replayed nonce should be rejected");
         assert!(
             result
@@ -1752,7 +1756,9 @@ mod sshauth_tests {
 
         let nonce = "cb-mismatch-test12345";
         let cb_signer = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-        let cb_verifier = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+        let cb_verifier = varlink_http_bridge::TlsChannelBinding::new(
+            "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+        );
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
@@ -1767,7 +1773,7 @@ mod sshauth_tests {
             "/sockets",
             Some(&header),
             Some(nonce),
-            Some(cb_verifier),
+            Some(&cb_verifier),
         );
         assert!(
             result.is_err(),
@@ -1781,17 +1787,19 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "cb-match-test-123456";
-        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let cb = varlink_http_bridge::TlsChannelBinding::new(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
             .action("nonce", nonce)
-            .action("tls-channel-binding", cb);
+            .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(cb))
+        auth.check_request("GET", "/sockets", Some(&header), Some(nonce), Some(&cb))
             .expect("matching channel binding should pass");
     }
 

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -14,6 +14,7 @@ use tokio::net::UnixStream;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::{self, Message};
+use varlink_http_bridge::TlsChannelBinding;
 
 #[cfg(feature = "sshauth")]
 mod sshauth_client;
@@ -86,7 +87,7 @@ async fn connect_tls<S: AsyncStream + 'static>(
     verify_hostname: bool,
     stream: S,
     error_context: &'static str,
-) -> Result<(BoxedStream, Option<String>)> {
+) -> Result<(BoxedStream, Option<TlsChannelBinding>)> {
     let connector = build_ssl_connector()?;
     let mut config = connector.configure().context("SSL configure")?;
     config.set_verify_hostname(verify_hostname);
@@ -118,7 +119,10 @@ fn parse_vsock_url(url: &str) -> Result<(u32, u32, String)> {
     Ok((cid, port, path.to_string()))
 }
 
-async fn connect_vsock(url: &str, use_tls: bool) -> Result<(BoxedStream, String, Option<String>)> {
+async fn connect_vsock(
+    url: &str,
+    use_tls: bool,
+) -> Result<(BoxedStream, String, Option<TlsChannelBinding>)> {
     let (cid, port, path) = parse_vsock_url(url)?;
     debug!("connecting to vsock CID {cid}:{port} (tls: {use_tls})");
     let raw_stream = tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(cid, port))
@@ -139,7 +143,7 @@ async fn connect_vsock(url: &str, use_tls: bool) -> Result<(BoxedStream, String,
     }
 }
 
-async fn connect_tcp(url: &str) -> Result<(BoxedStream, String, Option<String>)> {
+async fn connect_tcp(url: &str) -> Result<(BoxedStream, String, Option<TlsChannelBinding>)> {
     let ws_url = if let Some(rest) = url.strip_prefix("https://") {
         format!("wss://{rest}")
     } else if let Some(rest) = url.strip_prefix("http://") {
@@ -191,7 +195,7 @@ async fn connect_ws(url: &str) -> Result<Ws> {
     sshauth_client::connect_with_ssh_retry(async |key| {
         let (stream, mut request, tcb) = connect_transport(url).await?;
         if let Some(key) = key {
-            sshauth_client::add_auth_headers(&mut request, key, tcb.as_deref()).await?;
+            sshauth_client::add_auth_headers(&mut request, key, tcb.as_ref()).await?;
         }
         ws_upgrade(request, stream, tcb.is_some()).await
     })
@@ -208,7 +212,11 @@ async fn connect_ws(url: &str) -> Result<Ws> {
 /// over it before the WebSocket upgrade.
 async fn connect_transport(
     url: &str,
-) -> Result<(BoxedStream, tungstenite::http::Request<()>, Option<String>)> {
+) -> Result<(
+    BoxedStream,
+    tungstenite::http::Request<()>,
+    Option<TlsChannelBinding>,
+)> {
     use tungstenite::client::IntoClientRequest;
 
     let (stream, ws_url, tls_channel_binding) = if let Some(rest) = url.strip_prefix("vsock+tls://")

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use anyhow::{Context, Result, bail};
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
-use varlink_http_bridge::SSHAUTH_MAGIC_PREFIX;
+use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding};
 
 /// An SSH key that can be used for authentication.
 pub(crate) enum SshKey {
@@ -57,7 +57,7 @@ impl fmt::Display for SshKey {
 pub(crate) async fn add_auth_headers(
     request: &mut tungstenite::http::Request<()>,
     key: &SshKey,
-    tls_channel_binding: Option<&str>,
+    tls_channel_binding: Option<&TlsChannelBinding>,
 ) -> Result<()> {
     // to_string: ends the borrow of `request` before headers_mut() below
     let path_and_query = request
@@ -234,7 +234,7 @@ async fn sign_with_key(
     key: &SshKey,
     method: &str,
     path_and_query: &str,
-    tls_channel_binding: Option<&str>,
+    tls_channel_binding: Option<&TlsChannelBinding>,
 ) -> Result<(String, String)> {
     let nonce = generate_nonce();
 
@@ -261,7 +261,7 @@ async fn sign_with_key(
         .action("nonce", &nonce)
         .action(
             "tls-channel-binding",
-            tls_channel_binding.unwrap_or_default(),
+            tls_channel_binding.map_or("", TlsChannelBinding::as_str),
         );
     let token: sshauth::token::Token = tb.sign().await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,27 @@ pub const TLS_CHANNEL_BINDING_LABEL: &str = "EXPORTER-Channel-Binding";
 /// Output length (bytes) for TLS channel binding export.
 pub const TLS_CHANNEL_BINDING_LEN: usize = 32;
 
+/// Base64-encoded RFC 9266 channel binding of a TLS 1.3 session.
+///
+/// Newtype: signing or verifying over one of the look-alike strings it
+/// travels next to (URLs, tokens, nonces) would silently lose its relay
+/// protection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsChannelBinding(String);
+
+impl TlsChannelBinding {
+    /// Test-only: real bindings come from [`export_tls_channel_binding`].
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Export the TLS channel binding value from an established TLS 1.3 session.
 ///
 /// Returns the base64-encoded result of `export_keying_material` per RFC 9266.
@@ -60,7 +81,7 @@ pub const TLS_CHANNEL_BINDING_LEN: usize = 32;
 /// Panics if `export_keying_material` fails (should never happen with
 /// TLS 1.3) or if the export does not work because of an underlying
 /// bug in openssl and returns only zeros (should also never happen).
-pub fn export_tls_channel_binding(ssl: &openssl::ssl::SslRef) -> String {
+pub fn export_tls_channel_binding(ssl: &openssl::ssl::SslRef) -> TlsChannelBinding {
     let mut buf = [0u8; TLS_CHANNEL_BINDING_LEN];
     ssl.export_keying_material(&mut buf, TLS_CHANNEL_BINDING_LABEL, Some(&[]))
         .expect("export_keying_material must succeed with TLS 1.3");
@@ -68,7 +89,7 @@ pub fn export_tls_channel_binding(ssl: &openssl::ssl::SslRef) -> String {
         buf.iter().any(|&b| b != 0),
         "TLS channel binding must not be all zeros"
     );
-    openssl::base64::encode_block(&buf)
+    TlsChannelBinding(openssl::base64::encode_block(&buf))
 }
 
 /// Enable `TCP_NODELAY` and `SO_KEEPALIVE` on a TCP socket.


### PR DESCRIPTION
auth: pass AuthRequest to Authenticator::check_request

This commit replaces positional check_request() parameters with a
single struct carrying the raw headers. Auth methods now extract what
they need themselves so adding a new auth method no longer changes the
trait for the existing ones.

This will be useful for jwt-auth and api-keys-auth.

---

The RFC 9266 channel binding so far was just a string. This is not ideal as its not self-documenting and also not type safe (it should be impossible to pass it into the wrong place, this is not python afterall).

So this commit uses the newtype pattern to simply make it a proper type to ensure the issues above are fixed.

