### PR TITLE
test: fix race in integration tests

### DIFF
--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1132,7 +1132,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
         "expected failure without client cert, but helper succeeded"
     );
     assert!(
-        stderr.contains("handshake failed: check client cert if server requires mTLS"),
+        stderr.contains("check client cert if server requires mTLS"),
         "expected mTLS hint in error, got: {stderr}"
     );
 }

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::BorrowedFd;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
@@ -375,8 +375,18 @@ async fn main() -> Result<()> {
     };
 
     // Safety: fd 3 is passed to us via the sd_listen_fds() protocol.
-    let fd3 = unsafe { OwnedFd::from_raw_fd(3) };
-    rustix::io::fcntl_getfd(&fd3).context("fd 3 is not valid (LISTEN_FDS protocol error?)")?;
+    let fd3 = unsafe { BorrowedFd::borrow_raw(3) };
+    rustix::io::fcntl_getfd(fd3).context("fd 3 is not valid (LISTEN_FDS protocol error?)")?;
+    // We are called by systemds "varlinkctl" which monitors fd3 and
+    // if that closes immediately kills us. The implication of this is
+    // that closing it too early can lead to us getting killed before
+    // we had a chance to e.g. print a "connection failed" or similar
+    // messages. So we never take ownership of fd3 itself (it stays
+    // open until the OS closes it at process exit) and work on a
+    // duplicate instead. This guarantees varlinkctl cannot see EOF
+    // (and SIGTERM us) before any error output has reached stderr or
+    // any cleanup has happened.
+    let fd3 = fd3.try_clone_to_owned().context("duplicating fd 3")?;
     let fd3 = std::os::unix::net::UnixStream::from(fd3);
     fd3.set_nonblocking(true)?;
     let fd3 = UnixStream::from_std(fd3)?;


### PR DESCRIPTION
This PR fixes a race in the integration tests that can also happen on real systems - if we close fd3 too early in the bridge helper binary then systemds varlinkctl will kill us before we get the chance to print the rigth error message. See the invidivdual commits.

The other fix is the  message change that went undetected because CI has a too old version of varlinkctl to run this part of the tests :(T