### PR TITLE
httpd: allow passing multiple `varlink-httpd.ssh.authorized-keys.*`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-stream = "0.3"
 axum = { version = "0.8.8", features = ["ws"] }
 futures-core = "0.3"
 serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["full"] }
+tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "process", "fs", "signal"] }
 # not using default features as we don't need service/server/introspection
 zlink = { version = "0.7", default-features = false, features = ["tokio", "proxy", "idl-parse", "tracing"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -328,11 +328,22 @@ Ed25519 and ECDSA keys.
 #### Server setup
 
 The bridge discovers authorized keys automatically from these
-locations (first match wins):
+locations:
 
-1. `--authorized-keys PATH` — explicit CLI flag
+1. `--authorized-keys PATH` — explicit CLI flag; when given it is the only
+   source used
 2. `/etc/varlink-httpd/authorized_keys` — config file
-3. `$CREDENTIALS_DIRECTORY/ssh.authorized_keys.root` — systemd credential (see `systemd.exec(5)`)
+3. `$CREDENTIALS_DIRECTORY/ssh.authorized_keys.root` and
+   `ssh.ephemeral-authorized_keys-all` — systemd credentials (see
+   `systemd.exec(5)`)
+4. `$CREDENTIALS_DIRECTORY/varlink-httpd.ssh.authorized-keys.*` — additional
+   credentials, imported by the unit using a glob. Each provider (a
+   generated node config, a local admin, a confext) ships its own
+   `/etc/credstore/varlink-httpd.ssh.authorized-keys.<provider>` rather than
+   overwriting a shared file, which neither the credstore nor overlaid
+   confexts can merge.
+
+Keys from 2, 3 and 4 are merged and deduplicated.
 
 The simplest setup is to pass the path explicitly:
 

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -51,6 +51,7 @@ ImportCredential=varlink-httpd.tls.trust:trust
 # SSH authorized keys (see systemd.system-credentials(7))
 ImportCredential=ssh.authorized_keys.root
 ImportCredential=ssh.ephemeral-authorized_keys-all
+ImportCredential=varlink-httpd.ssh.authorized-keys.*
 
 [Install]
 WantedBy=network.target

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -308,6 +308,30 @@ const SSH_AUTHORIZED_KEYS_CREDENTIALS: &[&str] = &[
     "ssh.ephemeral-authorized_keys-all",
 ];
 
+/// One credential per provider, because neither the credstore nor overlaid
+/// confexts can merge the contents of a shared file.
+const SSH_AUTHORIZED_KEYS_PREFIX: &str = "varlink-httpd.ssh.authorized-keys.";
+
+/// Sorted so the merge order is stable. Enumerated rather than watched like
+/// the names above: systemd fills `$CREDENTIALS_DIRECTORY` at unit start and
+/// it is read-only after, so no new match can appear while we run.
+fn ssh_authorized_keys_prefixed(dir: &std::path::Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<String> = entries
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with(SSH_AUTHORIZED_KEYS_PREFIX))
+        })
+        .map(|e| e.path().to_string_lossy().into_owned())
+        .collect();
+    paths.sort();
+    paths
+}
+
 pub(crate) fn create_ssh_authenticator(
     cli_authorized_keys: Option<String>,
     creds_dir: Option<&std::path::Path>,
@@ -329,6 +353,7 @@ pub(crate) fn create_ssh_authenticator(
             for name in SSH_AUTHORIZED_KEYS_CREDENTIALS {
                 paths.push(d.join(name).to_string_lossy().to_string());
             }
+            paths.extend(ssh_authorized_keys_prefixed(d));
         }
         paths
     };

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1950,6 +1950,53 @@ mod sshauth_tests {
         );
     }
 
+    #[test]
+    fn test_ssh_auth_multiple_authorized_keys_credentials() {
+        let keygen_dir_a = tempfile::tempdir().unwrap();
+        let (pubkey_a, _) = generate_ed25519_keypair(keygen_dir_a.path());
+        let keygen_dir_b1 = tempfile::tempdir().unwrap();
+        let (pubkey_b1, _) = generate_ed25519_keypair(keygen_dir_b1.path());
+        let keygen_dir_b2 = tempfile::tempdir().unwrap();
+        let (pubkey_b2, _) = generate_ed25519_keypair(keygen_dir_b2.path());
+        let empty_root = tempfile::tempdir().unwrap();
+
+        // Credentials and the well-known names are merged into a list.
+        // The order is stable.
+        let creds_dir_multi = tempfile::tempdir().unwrap();
+        std::fs::write(
+            creds_dir_multi.path().join("ssh.authorized_keys.root"),
+            pubkey_a.as_bytes(),
+        )
+        .unwrap();
+        std::fs::write(
+            creds_dir_multi
+                .path()
+                .join("varlink-httpd.ssh.authorized-keys.nodeconfig"),
+            format!("{}\n", pubkey_b1.trim()),
+        )
+        .unwrap();
+        std::fs::write(
+            creds_dir_multi
+                .path()
+                .join("varlink-httpd.ssh.authorized-keys.local"),
+            format!("{}\n", pubkey_b2.trim()),
+        )
+        .unwrap();
+        // An unrelated credential in the same directory must not be read.
+        std::fs::write(
+            creds_dir_multi.path().join("varlink-httpd.tls.certificate"),
+            b"not a key",
+        )
+        .unwrap();
+        let auth = create_ssh_authenticator(None, Some(creds_dir_multi.path()), empty_root.path())
+            .unwrap();
+        assert_eq!(
+            auth.key_count(),
+            3,
+            ".root (1 key) + two per-provider credentials (1 key each) should be merged"
+        );
+    }
+
     #[test_with::path(/usr/bin/varlinkctl)]
     #[test_with::path(/run/systemd/io.systemd.Hostname)]
     #[tokio::test]


### PR DESCRIPTION
Allow multiple credentials `varlink-httpd.ssh.authorized-keys.*` to get imported. This can be useful if e.g. one comes via imds and one via a ESP credential.