### PR TITLE
cargo: run `cargo build` to refresh the Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,29 +1576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,15 +1805,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.1",
-]
 
 [[package]]
 name = "regex"
@@ -2266,7 +2234,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ssh-key",
- "sshauth",
+ "sshauth 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "ureq",
 ]
@@ -2276,6 +2244,25 @@ name = "sshauth"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4662c4c0ef49fc8a934c0a1498ff821b8a857721f26d8fb96386ff974a33d095"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "ecdsa",
+ "p256",
+ "postcard",
+ "serde",
+ "sha2",
+ "slog",
+ "ssh-encoding",
+ "ssh-key",
+ "tokio",
+]
+
+[[package]]
+name = "sshauth"
+version = "0.1.2"
+source = "git+https://github.com/mvo5/sshauth.git?branch=add-support-for-SkEd25519#afd9b4e549d0e9229c2910c94aa7bca76623dfdb"
 dependencies = [
  "anyhow",
  "base64",
@@ -2366,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "test-with"
-version = "0.16.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01f5d2f06061c078f7c5f3a3175fccb570c31f09439c41a41020584a8c578d9"
+checksum = "577e034de553ad1a2f3a62c711080f5095afb875da2e482646c7ad89e3c88428"
 dependencies = [
  "libtest-mimic",
  "test-with-derive",
@@ -2376,14 +2363,14 @@ dependencies = [
 
 [[package]]
 name = "test-with-derive"
-version = "0.16.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eff264ce57c3e33649f0342270e3ac96467b2a8c0b70b380b8c84764918f0f"
+checksum = "c7b0d3f97e986691b2c1c63d6f3de480f203eac42e51eb0bbb7e98abb897b06d"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2425,7 +2412,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2738,7 +2724,7 @@ dependencies = [
  "socket2",
  "ssh-key",
  "ssh-key-import",
- "sshauth",
+ "sshauth 0.1.2 (git+https://github.com/mvo5/sshauth.git?branch=add-support-for-SkEd25519)",
  "tempfile",
  "test-with",
  "tokio",
@@ -2746,6 +2732,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tokio-vsock",
  "tower",
+ "varlink-http-bridge",
  "vsock",
  "zlink",
 ]
@@ -3030,19 +3017,20 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b895b99588dceb73f4d349b8323eabad9a97d48ce83698d475c7223727c6148"
+checksum = "dd5961645cac87b613e8b3c6fb1743a567e6459bc8c1d00f7bf9884020fc98d4"
 dependencies = [
+ "zlink-core",
  "zlink-smol",
  "zlink-tokio",
 ]
 
 [[package]]
 name = "zlink-core"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd12701bd1d42a982b931f0159cf5054bf13d90e7828a8377dfc02ed4b00342d"
+checksum = "0314bb8bc5a5693f4625a6ea9681731a5f4bcc0a952bfca28184f268db15dcc2"
 dependencies = [
  "futures-util",
  "itoa",
@@ -3053,26 +3041,36 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "winnow",
+ "zlink-idl",
  "zlink-macros",
 ]
 
 [[package]]
-name = "zlink-macros"
-version = "0.5.0"
+name = "zlink-idl"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f2416a5f504dfd7e04fee49f31abafe3314a3f62b4ddaa8e9a5fd496d4dd50"
+checksum = "a7990f15bd88a2b37d55c5fc13a1dd662ee98674ec9c6ac904fe46066523932a"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "zlink-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc623b8323797bf2d48333e7633e143077dd92cc66d9cca170014b66c43b1b5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+ "zlink-idl",
 ]
 
 [[package]]
 name = "zlink-smol"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc53cd0d636ad753f759aab0abb1f456e985c3938a279d11ebda92340ae37b1"
+checksum = "4bc4150b8af92eb0ae7007e0ced3eb2bcf8a7fa49457de2f30b11752ea538f46"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -3085,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "zlink-tokio"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cbf366ac77ab41bf9a8d43535d3d620a072f7957813e03355d3d010c16cc4f"
+checksum = "4c4fe0f232dd656bcb0594e9646b86c69f6257e3d5194f28715a044c4d10c8fa"
 dependencies = [
  "futures-util",
  "pin-project-lite",


### PR DESCRIPTION
When https://github.com/systemd/varlink-http-bridge/pull/81 got merge it had a stale Cargo.lock. Thie commit updates it.