### PR TITLE
Add service reload support to configure creds without a restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -281,9 +281,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -353,7 +353,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -590,7 +590,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -752,9 +752,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "foreign-types"
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -807,15 +807,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -843,32 +843,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1039,9 +1039,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1351,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchit"
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polling"
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2042,7 +2042,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2286,63 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sshauth"
-version = "0.1.2"
-source = "git+https://github.com/mvo5/sshauth.git?branch=add-support-for-SkEd25519#afd9b4e549d0e9229c2910c94aa7bca76623dfdb"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "ecdsa",
- "p256",
- "postcard",
- "serde",
- "sha2",
- "slog",
- "ssh-encoding",
- "ssh-key",
- "tokio",
-]
-
-[[package]]
-name = "sshauth"
-version = "0.1.2"
-source = "git+https://github.com/mvo5/sshauth.git?branch=add-support-for-SkEd25519#afd9b4e549d0e9229c2910c94aa7bca76623dfdb"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "ecdsa",
- "p256",
- "postcard",
- "serde",
- "sha2",
- "slog",
- "ssh-encoding",
- "ssh-key",
- "tokio",
-]
-
-[[package]]
-name = "sshauth"
-version = "0.1.2"
-source = "git+https://github.com/mvo5/sshauth.git?branch=add-support-for-SkEd25519#afd9b4e549d0e9229c2910c94aa7bca76623dfdb"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "ecdsa",
- "p256",
- "postcard",
- "serde",
- "sha2",
- "slog",
- "ssh-encoding",
- "ssh-key",
- "tokio",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2434,27 +2377,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2492,7 +2435,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2755,9 +2698,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2849,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2862,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2872,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2882,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2895,18 +2838,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3001,18 +2944,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3076,7 +3019,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ locations:
 
 Keys from 2, 3 and 4 are merged and deduplicated.
 
+All sources are re-read when they change (checked lazily on each
+request), so key updates need no restart.
+
 The simplest setup is to pass the path explicitly:
 
 ```console

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -53,5 +53,7 @@ ImportCredential=ssh.authorized_keys.root
 ImportCredential=ssh.ephemeral-authorized_keys-all
 ImportCredential=varlink-httpd.ssh.authorized-keys.*
 
+RefreshOnReload=credentials
+
 [Install]
 WantedBy=network.target

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -10,19 +10,19 @@ use std::time::{Instant, SystemTime};
 use crate::{AuthRequest, Authenticator};
 use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding};
 
-/// One tracked `authorized_keys` file: its mtime when last read and the
-/// (fingerprint -> key) map of supported keys it contained. Bundling
-/// these avoids having to keep the per-path mtime in a second map in
-/// lockstep with the keys.
+/// One tracked `authorized_keys` file: its mtime when last read (`None`
+/// means tracked but absent) and the (fingerprint -> key) map of supported
+/// keys it contained. Bundling these avoids having to keep the per-path
+/// mtime in a second map in lockstep with the keys.
 struct AuthKeysFile {
-    mtime: SystemTime,
+    mtime: Option<SystemTime>,
     keys: HashMap<String, PublicKey>,
 }
 
 impl AuthKeysFile {
     /// Stat `path`, folding `NotFound` into `Ok(None)` so missing files are
     /// treated as "tracked absence" rather than a hard error.
-    fn stat_mtime(path: &str) -> std::io::Result<Option<SystemTime>> {
+    fn stat_mtime(path: impl AsRef<std::path::Path>) -> std::io::Result<Option<SystemTime>> {
         match std::fs::metadata(path).and_then(|m| m.modified()) {
             Ok(m) => Ok(Some(m)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -55,40 +55,66 @@ impl AuthKeysFile {
         Ok(keys)
     }
 
-    /// Stat and parse `path`. Returns `Ok(None)` if the file does not
-    /// exist yet (it will be picked up by `maybe_reload` once it appears).
-    fn load(path: &str) -> anyhow::Result<Option<Self>> {
-        let mtime = match Self::stat_mtime(path) {
-            Ok(Some(m)) => m,
-            Ok(None) => return Ok(None),
-            Err(e) => {
-                return Err(anyhow::Error::new(e).context(format!("failed to stat {path}")));
-            }
+    /// Stat and parse `path`. A file that does not exist yet becomes a
+    /// tracked-absence entry (no mtime, no keys) that `maybe_reload`
+    /// fills in once the file appears.
+    fn load(path: &str) -> anyhow::Result<Self> {
+        let mtime = Self::stat_mtime(path)
+            .map_err(|e| anyhow::Error::new(e).context(format!("failed to stat {path}")))?;
+        let keys = match mtime {
+            Some(_) => Self::parse_keys(path)?,
+            None => HashMap::new(),
         };
-        let keys = Self::parse_keys(path)?;
-        Ok(Some(Self { mtime, keys }))
+        Ok(Self { mtime, keys })
     }
 }
 
 struct KeyCache {
+    /// All tracked paths, including absent ones (tracks absence as entries
+    /// with no mtime). The prefixed credentials are re-enumerated (and the
+    /// map rebuilt) when the credentials-directory mtime changes.
     files: HashMap<String, AuthKeysFile>,
+    /// mtime of the credentials directory (if it exist)
+    creds_dir_mtime: Option<SystemTime>,
 }
 
 impl KeyCache {
     /// Initial load of all tracked paths. Files that do not (yet) exist
-    /// are silently skipped; they will be picked up by `reload` once
-    /// they appear. Parse errors propagate (startup should fail loud).
-    fn load_all(paths: &[String]) -> anyhow::Result<Self> {
+    /// are tracked as absent and picked up by `maybe_reload` once they
+    /// appear. Parse errors propagate (startup should fail loud).
+    fn load_all(
+        static_paths: &[String],
+        creds_dir: Option<&std::path::Path>,
+    ) -> anyhow::Result<Self> {
+        let creds_dir_mtime = match creds_dir {
+            Some(dir) => AuthKeysFile::stat_mtime(dir)
+                .with_context(|| format!("failed to stat {}", dir.display()))?,
+            None => None,
+        };
+        let prefixed_paths = creds_dir
+            .map(ssh_authorized_keys_prefixed)
+            .unwrap_or_default();
         let mut files = HashMap::new();
-        for path in paths {
-            match AuthKeysFile::load(path)? {
-                Some(f) => {
-                    files.insert(path.clone(), f);
-                }
-                None => info!("authorized keys file {path} does not exist yet, skipping"),
+        for path in static_paths.iter().cloned().chain(prefixed_paths) {
+            let f = AuthKeysFile::load(&path)?;
+            if f.mtime.is_none() {
+                info!(
+                    "authorized keys file {path} does not exist yet, will pick it up when it appears"
+                );
             }
+            files.insert(path, f);
         }
-        Ok(Self { files })
+        Ok(Self {
+            files,
+            creds_dir_mtime,
+        })
+    }
+
+    /// All tracked paths (sorted for stable output).
+    fn tracked_paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self.files.keys().cloned().collect();
+        paths.sort();
+        paths
     }
 
     /// Number of distinct key fingerprints across all tracked files.
@@ -122,15 +148,14 @@ impl KeyCache {
         fps.into_iter().collect()
     }
 
-    /// Ok(true) if any `path` in `paths` has an mtime that differs from
-    /// what this cache has recorded (including "file now exists" and
-    /// "file now gone"). Err carries the path that failed a transient
-    /// stat so the caller can log it.
-    fn any_mtime_changed(&self, paths: &[String]) -> Result<bool, (String, std::io::Error)> {
-        for path in paths {
+    /// Ok(true) if any tracked file's mtime differs from what this cache
+    /// has recorded (including "file now exists" and "file now gone").
+    /// Err carries the path that failed a transient stat so the caller
+    /// can log it.
+    fn any_mtime_changed(&self) -> Result<bool, (String, std::io::Error)> {
+        for (path, f) in &self.files {
             let now = AuthKeysFile::stat_mtime(path).map_err(|e| (path.clone(), e))?;
-            let cached = self.files.get(path).map(|f| f.mtime);
-            if now != cached {
+            if now != f.mtime {
                 return Ok(true);
             }
         }
@@ -140,10 +165,39 @@ impl KeyCache {
     /// If any tracked path has changed on disk, re-read it; transient
     /// stat errors are logged and the cache is left untouched (retried
     /// on the next call).
-    fn maybe_reload(&mut self, paths: &[String]) {
-        match self.any_mtime_changed(paths) {
+    fn maybe_reload(&mut self, static_paths: &[String], creds_dir: Option<&std::path::Path>) {
+        // A changed credentials-directory mtime means credentials were added
+        // or removed (systemd's RefreshOnReload= swaps in a whole new tree on
+        // `systemctl reload`), so re-enumerate the prefixed credentials
+        // instead of only re-reading the already known paths.
+        if let Some(dir) = creds_dir {
+            match AuthKeysFile::stat_mtime(dir) {
+                Ok(mtime) if mtime != self.creds_dir_mtime => {
+                    self.creds_dir_mtime = mtime;
+                    // Reset the list to the static paths
+                    let mut paths = static_paths.to_vec();
+                    // Pick up newly discovered creds paths
+                    paths.extend(ssh_authorized_keys_prefixed(dir));
+                    // Do a full reload, no need to check the other mtimes
+                    self.reload(&paths);
+                    return;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(
+                        "cannot stat {dir}: {e}, skipping reload (keeping cached keys)",
+                        dir = dir.display(),
+                    );
+                    return;
+                }
+            }
+        }
+        match self.any_mtime_changed() {
             Ok(false) => {}
-            Ok(true) => self.reload(paths),
+            Ok(true) => {
+                let paths = self.tracked_paths();
+                self.reload(&paths);
+            }
             Err((path, e)) => {
                 // Transient error (permissions, IO): skip this reload cycle
                 // rather than risk dropping valid keys. Retry next request.
@@ -153,27 +207,35 @@ impl KeyCache {
     }
 
     /// Re-read all `paths` into this cache, replacing previously tracked
-    /// entries. On parse errors the file's mtime is still recorded (with
-    /// empty keys) so we don't log-spam the same warning on every request
-    /// until the file changes again.
+    /// entries. Gone or unreadable files stay tracked as absent (dropping
+    /// their cached keys). On parse errors the file's mtime is still
+    /// recorded (with empty keys) so we don't log-spam the same warning
+    /// on every request until the file changes again.
     fn reload(&mut self, paths: &[String]) {
         let mut new_files = HashMap::new();
         for path in paths {
-            let Ok(Some(mtime)) = AuthKeysFile::stat_mtime(path) else {
-                continue; // file is gone or unreadable; drop its cached keys
-            };
-            let keys = match AuthKeysFile::parse_keys(path) {
-                Ok(keys) => {
-                    info!(
-                        "reloaded {count} SSH key(s) from {path} (file changed)",
-                        count = keys.len(),
-                    );
-                    keys
-                }
+            let mtime = match AuthKeysFile::stat_mtime(path) {
+                Ok(m) => m,
                 Err(e) => {
-                    warn!("failed to reload {path}: {e:#}, skipping this source");
-                    HashMap::new()
+                    warn!("cannot stat {path}: {e}, treating as absent (will retry)");
+                    None
                 }
+            };
+            let keys = match mtime {
+                Some(_) => match AuthKeysFile::parse_keys(path) {
+                    Ok(keys) => {
+                        info!(
+                            "reloaded {count} SSH key(s) from {path} (file changed)",
+                            count = keys.len(),
+                        );
+                        keys
+                    }
+                    Err(e) => {
+                        warn!("failed to reload {path}: {e:#}, skipping this source");
+                        HashMap::new()
+                    }
+                },
+                None => HashMap::new(),
             };
             new_files.insert(path.clone(), AuthKeysFile { mtime, keys });
         }
@@ -235,25 +297,30 @@ impl NonceStore {
 }
 
 pub(crate) struct SshKeyAuthenticator {
-    paths: Vec<String>,
+    static_paths: Vec<String>,
+    creds_dir: Option<std::path::PathBuf>,
     max_skew: u64,
     authorized_keys: Mutex<KeyCache>,
     nonces: Mutex<NonceStore>,
 }
 
 impl SshKeyAuthenticator {
-    pub(crate) fn new(paths: Vec<String>) -> anyhow::Result<Self> {
-        let cache = KeyCache::load_all(&paths)?;
+    pub(crate) fn new(
+        static_paths: Vec<String>,
+        creds_dir: Option<std::path::PathBuf>,
+    ) -> anyhow::Result<Self> {
+        let cache = KeyCache::load_all(&static_paths, creds_dir.as_deref())?;
         if cache.unique_key_count() == 0 {
             warn!(
                 "no supported SSH public keys in {} (note: RSA is not supported, use Ed25519 or ECDSA); SSH auth will reject all requests until keys appear",
-                paths.join(", "),
+                cache.tracked_paths().join(", "),
             );
         }
 
         let max_skew = 60;
         Ok(Self {
-            paths,
+            static_paths,
+            creds_dir,
             max_skew,
             authorized_keys: Mutex::new(cache),
             nonces: Mutex::new(NonceStore::new(max_skew)),
@@ -262,6 +329,11 @@ impl SshKeyAuthenticator {
 
     pub(crate) fn key_count(&self) -> usize {
         self.authorized_keys.lock().unwrap().unique_key_count()
+    }
+
+    /// All currently tracked source paths (only for logging).
+    pub(crate) fn sources(&self) -> Vec<String> {
+        self.authorized_keys.lock().unwrap().tracked_paths()
     }
 
     #[cfg(test)]
@@ -276,7 +348,7 @@ impl SshKeyAuthenticator {
         self.authorized_keys
             .lock()
             .unwrap()
-            .maybe_reload(&self.paths);
+            .maybe_reload(&self.static_paths, self.creds_dir.as_deref());
     }
 }
 
@@ -285,7 +357,8 @@ impl std::fmt::Debug for SshKeyAuthenticator {
         let ak = self.authorized_keys.lock().unwrap();
         let fingerprints = ak.fingerprints();
         f.debug_struct("SshKeyAuthenticator")
-            .field("paths", &self.paths)
+            .field("static_paths", &self.static_paths)
+            .field("creds_dir", &self.creds_dir)
             .field("max_skew", &self.max_skew)
             .field("fingerprints", &fingerprints)
             .finish_non_exhaustive()
@@ -312,9 +385,10 @@ const SSH_AUTHORIZED_KEYS_CREDENTIALS: &[&str] = &[
 /// confexts can merge the contents of a shared file.
 const SSH_AUTHORIZED_KEYS_PREFIX: &str = "varlink-httpd.ssh.authorized-keys.";
 
-/// Sorted so the merge order is stable. Enumerated rather than watched like
-/// the names above: systemd fills `$CREDENTIALS_DIRECTORY` at unit start and
-/// it is read-only after, so no new match can appear while we run.
+/// Sorted so the merge order is stable. Re-enumerated whenever the
+/// directory's mtime changes: systemd fills `$CREDENTIALS_DIRECTORY` at unit
+/// start and, with `RefreshOnReload=credentials`, swaps in a fresh tree
+/// on `systemctl reload`, so new matches can appear while we run.
 fn ssh_authorized_keys_prefixed(dir: &std::path::Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
@@ -337,12 +411,13 @@ pub(crate) fn create_ssh_authenticator(
     creds_dir: Option<&std::path::Path>,
     root: &std::path::Path,
 ) -> anyhow::Result<SshKeyAuthenticator> {
-    let paths: Vec<String> = if let Some(cli_path) = cli_authorized_keys {
+    let (paths, creds_dir) = if let Some(cli_path) = cli_authorized_keys {
         // Explicit CLI path overrides all auto-discovery
-        vec![cli_path]
+        (vec![cli_path], None)
     } else {
-        // Register all well-known sources; files that don't exist yet
-        // will be picked up by maybe_reload() once they appear.
+        // Register all well-known sources; files that don't exist yet will be
+        // picked up by maybe_reload() once they appear, and the prefixed
+        // credentials are re-enumerated when the directory changes.
         let mut paths = Vec::new();
         paths.push(
             root.join("etc/varlink-httpd/authorized_keys")
@@ -353,16 +428,15 @@ pub(crate) fn create_ssh_authenticator(
             for name in SSH_AUTHORIZED_KEYS_CREDENTIALS {
                 paths.push(d.join(name).to_string_lossy().to_string());
             }
-            paths.extend(ssh_authorized_keys_prefixed(d));
         }
-        paths
+        (paths, creds_dir.map(std::path::Path::to_path_buf))
     };
 
-    let ssh_auth = SshKeyAuthenticator::new(paths.clone())?;
+    let ssh_auth = SshKeyAuthenticator::new(paths, creds_dir)?;
     info!(
         "Authenticator: adding SSH authorized keys ({count} keys from {sources})",
         count = ssh_auth.key_count(),
-        sources = paths.join(", "),
+        sources = ssh_auth.sources().join(", "),
     );
     Ok(ssh_auth)
 }
@@ -372,7 +446,7 @@ impl Authenticator for SshKeyAuthenticator {
         self.authorized_keys
             .lock()
             .unwrap()
-            .maybe_reload(&self.paths);
+            .maybe_reload(&self.static_paths, self.creds_dir.as_deref());
 
         let (method, path) = (request.method, request.path);
         let token_str = request.bearer_token()?;

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1558,10 +1558,13 @@ mod sshauth_tests {
         std::fs::write(&file_a, pubkey_a.as_bytes()).unwrap();
         std::fs::write(&file_b, pubkey_b.as_bytes()).unwrap();
 
-        let auth = crate::auth_ssh::SshKeyAuthenticator::new(vec![
-            file_a.to_string_lossy().into_owned(),
-            file_b.to_string_lossy().into_owned(),
-        ])
+        let auth = crate::auth_ssh::SshKeyAuthenticator::new(
+            vec![
+                file_a.to_string_lossy().into_owned(),
+                file_b.to_string_lossy().into_owned(),
+            ],
+            None,
+        )
         .unwrap();
         assert_eq!(auth.key_count(), 2);
 
@@ -2061,6 +2064,48 @@ mod sshauth_tests {
             auth.key_count(),
             3,
             ".root (1 key) + two per-provider credentials (1 key each) should be merged"
+        );
+    }
+
+    #[test]
+    fn test_ssh_auth_prefixed_credential_appears_after_start() {
+        let keygen_dir_a = tempfile::tempdir().unwrap();
+        let (pubkey_a, _) = generate_ed25519_keypair(keygen_dir_a.path());
+        let keygen_dir_b = tempfile::tempdir().unwrap();
+        let (pubkey_b, _) = generate_ed25519_keypair(keygen_dir_b.path());
+        let empty_root = tempfile::tempdir().unwrap();
+
+        let creds_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            creds_dir
+                .path()
+                .join("varlink-httpd.ssh.authorized-keys.first"),
+            pubkey_a.as_bytes(),
+        )
+        .unwrap();
+        let auth =
+            create_ssh_authenticator(None, Some(creds_dir.path()), empty_root.path()).unwrap();
+        assert_eq!(auth.key_count(), 1);
+
+        // A prefixed credential appearing later (RefreshOnReload= swaps in a
+        // new tree on `systemctl reload`) is found via the directory mtime.
+        let new_cred = creds_dir
+            .path()
+            .join("varlink-httpd.ssh.authorized-keys.second");
+        std::fs::write(&new_cred, pubkey_b.as_bytes()).unwrap();
+        auth.reload_for_test();
+        assert_eq!(
+            auth.key_count(),
+            2,
+            "new prefixed credential should be re-enumerated"
+        );
+
+        std::fs::remove_file(&new_cred).unwrap();
+        auth.reload_for_test();
+        assert_eq!(
+            auth.key_count(),
+            1,
+            "removed prefixed credential should be dropped"
         );
     }
 


### PR DESCRIPTION
The live discovery of key changes worked only for the regular filesystem
path but not for the credential directory of the service. Systemd allows
to refresh credentials and we can use that to reload the keys without a
full service restart that would bring down existing connections.

Configure the service unit to refresh credentials and detect that
through an mtime check of the dir like we already do mtime checks for
the static key paths. Since we always do a full reload and not partially
patch single key entries, we also do a full reload when the creds dir
changes but before we do that we first have to reset the list of tracked
files and re-enumerate the creds paths by prefix. Simplify the model by
keeping a list of all tracked paths and using the mtime to mark absence
by allowing it to be None. This way we don't need to assemble a correct
list of paths to hand to any_mtime_changed but use that an appearing
entry compares differently to an absent entry through the mtime being
set now (or the reverse) and we do a reload.