### PR TITLE
tls: generate a self-signed server cert and pin it from the client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/varlinkctl-http/main.rs"
 
 [features]
 default = ["sshauth"]
-sshauth = ["dep:ssh-key", "dep:sshauth", "dep:tempfile", "dep:ssh-key-import"]
+sshauth = ["dep:ssh-key", "dep:sshauth", "dep:ssh-key-import"]
 # never enable directly: pulled in via the self dev-dependency so that
 # test-only constructors exist in test builds but not in release builds
 test-helpers = []
@@ -42,7 +42,7 @@ listenfd = "1.0.2"
 tokio-tungstenite = "0.30"
 futures-util = { version = "0.3" }
 bytes = "1"
-rustix = { version = "1.0", features = ["net", "process"] }
+rustix = { version = "1.0", features = ["net", "process", "system"] }
 # TODO: switch back to crates.io once tokio-vsock releases a version with
 # From<OwnedFd> support (https://github.com/rust-vsock/tokio-vsock/pull/72)
 tokio-vsock = { git = "https://github.com/rust-vsock/tokio-vsock.git", rev = "c6225086", features = ["axum08"] }
@@ -59,7 +59,7 @@ ssh-key = { version = "0.6", optional = true }
 # merged and released (https://github.com/mvo5/sshauth/tree/add-support-for-SkEd25519)
 # (see https://github.com/oxidecomputer/sshauth/pull/8)
 sshauth = { git = "https://github.com/mvo5/sshauth.git", branch = "add-support-for-SkEd25519", optional = true }
-tempfile = { version = "3.27", optional = true }
+tempfile = "3.27"
 ssh-key-import = { path = "crates/ssh-key-import", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ using the websocket endpoint.
 
 For demo purposes, let's first start the service *without authentication*.
 This mode is NOT SECURE! See below how to set up authentication.
+`--insecure` also turns TLS off, hence the plain `http://` below.
 
 ```console
 $ systemd-run --user ./target/debug/varlink-httpd --insecure
@@ -269,10 +270,20 @@ TLS flag names follow the systemd convention.
 --cert=PATH    path to TLS certificate PEM file
 --key=PATH     path to TLS private key PEM file
 --trust=PATH   path to CA certificate PEM for client verification (mTLS)
+--insecure     run over plain HTTP without any authentication (DANGEROUS)
 ```
 
 Providing `--trust=` implicitly enables mTLS: the server will
 require clients to present a certificate signed by that CA.
+
+Listeners always speak TLS unless `--insecure` is given. Without
+`--cert=`/`--key=` the bridge generates a self-signed certificate on
+first start, persists it under `$STATE_DIRECTORY`
+(`/var/lib/varlink-httpd` for the shipped unit) and prints the key to
+pin, e.g. `sha256//N/XBoWQvWrJScutg5/l0WO5sC1/QV2th677ylUNaVa8=`. The
+pin covers the public key, not the certificate, so regenerating the
+certificate from the same key keeps existing pins valid. Clients take it
+via `known-hosts` (see below) or `curl --pinnedpubkey`.
 
 #### systemd credentials
 
@@ -307,8 +318,13 @@ client TLS material in the first existing directory:
 | `client-cert-file`     | Client certificate PEM (for mTLS)         |
 | `client-key-file`      | Client private key PEM (for mTLS)         |
 | `server-ca-file`       | CA certificate PEM (for private/self-signed server CAs) |
+| `known-hosts`          | pinned server public keys, one line per peer |
 
-The system CAs are used automatically. For mTLS, drop the client cert
+The system CAs are used automatically. A certificate that validates
+against them (or against `server-ca-file`) is accepted as-is; a
+self-signed one is pinned in `known-hosts` instead, learned on first
+contact and refused if it later changes. The peer is `host:port`, or
+`vsock:CID:PORT` for vsock. For mTLS, drop the client cert
 and key into the config directory:
 
 ```console
@@ -431,15 +447,17 @@ to a guest's vsock port, so authentication is still recommended
 
 ### SSH key auth over vsock
 
-vsock with SSH key auth works without TLS — the transport is not
-sniffable so the lack of encryption is acceptable:
+vsock needs no CA: the guest serves its generated self-signed
+certificate and the host pins it on first contact, so SSH keys are the
+only material to provision. Plain `vsock://` speaks no TLS and reaches
+only an `--insecure` server.
 
 ```console
 # Server (inside the guest):
 $ varlink-httpd --bind=vsock --authorized-keys ~/.ssh/authorized_keys
 
 # Client (on the host):
-$ varlinkctl call vsock://3/ws/sockets/io.systemd.Hostname \
+$ varlinkctl call vsock+tls://3/ws/sockets/io.systemd.Hostname \
     io.systemd.Hostname.Describe '{}'
 ```
 

--- a/data/varlink-httpd.service.in
+++ b/data/varlink-httpd.service.in
@@ -18,6 +18,7 @@ Type=simple
 ExecStart=@bindir@/varlink-httpd
 Restart=on-failure
 RestartSec=5
+StateDirectory=varlink-httpd
 
 # Pass the FDs from both socket units in a single service start. Without
 # this, whichever socket triggers activation first wins the race; the

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -39,6 +39,7 @@ mod auth_ssh;
 #[cfg(feature = "sshauth")]
 mod import_ssh;
 mod openapi;
+mod tls_cert;
 mod ws_framing;
 
 use ws_framing::VarlinkFramer;
@@ -499,15 +500,17 @@ fn load_tls_acceptor(
     Ok(builder.build())
 }
 
-/// Resolve TLS configuration: explicit paths take priority, then fall back to
-/// systemd's $`CREDENTIALS_DIRECTORY` (see systemd.exec(5)), then no TLS.
+/// Resolve TLS configuration: explicit paths take priority, then systemd's
+/// $`CREDENTIALS_DIRECTORY` (see systemd.exec(5)), then a self-signed
+/// certificate generated and persisted under the state directory.
+///
 /// Credential file names match the CLI flag names: cert, key, trust.
 fn resolve_tls_acceptor(
     cli_cert: Option<String>,
     cli_key: Option<String>,
     cli_ca: Option<String>,
     creds_dir: Option<&std::path::Path>,
-) -> anyhow::Result<Option<openssl::ssl::SslAcceptor>> {
+) -> anyhow::Result<openssl::ssl::SslAcceptor> {
     let creds = creds_dir.map(varlink_http_bridge::sysconf::CredentialsLoader::from_dir);
     let cred = |name: &str| -> Option<String> {
         creds
@@ -521,12 +524,21 @@ fn resolve_tls_acceptor(
     let client_ca = cli_ca.or_else(|| cred("trust"));
 
     match (tls_cert.as_deref(), tls_key.as_deref()) {
-        (Some(cert), Some(key)) => Ok(Some(load_tls_acceptor(cert, key, client_ca.as_deref())?)),
+        (Some(cert), Some(key)) => load_tls_acceptor(cert, key, client_ca.as_deref()),
         (None, None) => {
-            if client_ca.is_some() {
-                bail!("--trust requires --cert and --key");
-            }
-            Ok(None)
+            // TLS is not optional, generate a self-signed cert.
+            let dir = tls_cert::state_dir()?;
+            let (cert_path, key_path) = tls_cert::load_or_generate(&dir)?;
+            tls_cert::print_pin(&cert_path)?;
+            load_tls_acceptor(
+                cert_path
+                    .to_str()
+                    .expect("failed to convert cert path to str"),
+                key_path
+                    .to_str()
+                    .expect("failed to convert key path to str"),
+                client_ca.as_deref(),
+            )
         }
         _ => bail!("--cert and --key must be specified together"),
     }
@@ -1251,10 +1263,13 @@ fn print_help() {
                                             default: 0.0.0.0:{DEFAULT_PORT})
                                             use vsock::PORT for vsock (e.g. vsock::{DEFAULT_PORT})
           --cert=PATH                       TLS certificate PEM file
+                                            (default: self-signed, generated
+                                            and persisted on first start)
           --key=PATH                        TLS private key PEM file
           --trust=PATH                      CA certificate PEM for client verification (mTLS)
           --authorized-keys=PATH            authorized SSH public keys file
-          --insecure                        run without any authentication (DANGEROUS)
+          --insecure                        run over plain HTTP without any
+                                            authentication (DANGEROUS)
           --help                            display this help and exit
     "}
     );
@@ -1379,7 +1394,21 @@ async fn main() -> anyhow::Result<()> {
     let has_mtls =
         cli.trust.is_some() || creds_dir.as_ref().is_some_and(|d| d.join("trust").exists());
 
-    let tls_acceptor = resolve_tls_acceptor(cli.cert, cli.key, cli.trust, creds_dir.as_deref())?;
+    let tls_acceptor = if cli.insecure {
+        None
+    } else {
+        Some(resolve_tls_acceptor(
+            cli.cert,
+            cli.key,
+            cli.trust,
+            creds_dir.as_deref(),
+        )?)
+    };
+    let scheme = if tls_acceptor.is_some() {
+        "HTTPS"
+    } else {
+        "HTTP"
+    };
 
     #[cfg(not(feature = "sshauth"))]
     if cli.authorized_keys.is_some() {
@@ -1420,12 +1449,6 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let app = create_router(&cli.varlink_sockets_path, authenticators)?;
-
-    let scheme = if tls_acceptor.is_some() {
-        "HTTPS"
-    } else {
-        "HTTP"
-    };
 
     // Socket activation: consume all activated fds, or fall back to explicit --bind
     // run with e.g. "systemd-socket-activate -l 127.0.0.1:1031 -- varlink-httpd"

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1126,8 +1126,7 @@ async fn test_tls_credentials_directory_fallback() {
 
     // No CLI flags; resolve_tls_acceptor should pick up creds from the directory
     let acceptor = resolve_tls_acceptor(None, None, None, Some(creds_dir.path()))
-        .expect("credentials directory fallback failed")
-        .expect("expected Some(acceptor) from credentials directory");
+        .expect("credentials directory fallback failed");
 
     let varlink_dir = tempfile::tempdir().unwrap();
     let server = run_test_tls_server(varlink_dir.path().to_str().unwrap(), acceptor).await;
@@ -1231,13 +1230,20 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
 }
 
 #[test]
-fn test_tls_credentials_directory_returns_none_without_creds() {
+fn test_tls_half_configured_is_rejected() {
     let empty_dir = tempfile::tempdir().unwrap();
-    let result = resolve_tls_acceptor(None, None, None, Some(empty_dir.path())).unwrap();
-    assert!(
-        result.is_none(),
-        "empty credentials dir should yield no TLS"
-    );
+    for (cert, key) in [
+        (Some("/nonexistent/cert.pem".to_string()), None),
+        (None, Some("/nonexistent/key.pem".to_string())),
+    ] {
+        let Err(err) = resolve_tls_acceptor(cert, key, None, Some(empty_dir.path())) else {
+            panic!("--cert and --key must be given together");
+        };
+        assert!(
+            format!("{err:#}").contains("must be specified together"),
+            "unexpected error: {err:#}"
+        );
+    }
 }
 
 #[test_with::path(/usr/bin/openssl)]

--- a/src/bin/varlink-httpd/tls_cert.rs
+++ b/src/bin/varlink-httpd/tls_cert.rs
@@ -3,9 +3,10 @@
 //! Self-signed server certificate management.
 //!
 //! TLS is mandatory for TCP listeners, so an operator who provides no
-//! `--cert`/`--key` still needs one. Rather than refusing to start, the
-//! bridge generates a long-lived self-signed certificate on first run and
-//! persists it alongside its key, mirroring how `sshd` treats host keys.
+//! `--cert`/`--key` (or no `cert`/`key` credential) still needs
+//! one. Rather than refusing to start, the bridge generates a
+//! long-lived self-signed certificate on first run and persists it
+//! alongside its key, mirroring how `sshd` treats host keys.
 //!
 //! It chains to nothing, so clients must pin it. The pin covers the public
 //! key, not the certificate, so regenerating the certificate from the same

--- a/src/bin/varlink-httpd/tls_cert.rs
+++ b/src/bin/varlink-httpd/tls_cert.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! Self-signed server certificate management.
+//!
+//! TLS is mandatory for TCP listeners, so an operator who provides no
+//! `--cert`/`--key` still needs one. Rather than refusing to start, the
+//! bridge generates a long-lived self-signed certificate on first run and
+//! persists it alongside its key, mirroring how `sshd` treats host keys.
+//!
+//! It chains to nothing, so clients must pin it. The pin covers the public
+//! key, not the certificate, so regenerating the certificate from the same
+//! key keeps every existing pin valid.
+
+use anyhow::{Context, bail};
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::ec::{EcGroup, EcKey};
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, Private};
+use openssl::x509::extension::{
+    BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
+};
+use openssl::x509::{X509, X509NameBuilder};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// Ten years. A self-signed certificate has no revocation story.
+const VALIDITY_DAYS: u32 = 3650;
+
+/// P-256 rather than Ed25519: the certificate has to be accepted by whatever
+/// HTTP client a user reaches for, and ECDSA support is universal where
+/// Ed25519 certificate support still is not.
+fn generate_keypair() -> anyhow::Result<PKey<Private>> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).context("selecting P-256 curve")?;
+    let ec = EcKey::generate(&group).context("generating P-256 key")?;
+    PKey::from_ec_key(ec).context("wrapping EC key")
+}
+
+/// Names this host is likely to be reached by.
+///
+/// Deliberately a short static list rather than anything clever.
+/// Users should rather pin the pub key (curl's `--pinnedpubkey`)
+/// for server verification in the auto-generated cert flow.
+fn default_sans() -> Vec<String> {
+    let mut sans = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    let uname = rustix::system::uname();
+    if let Ok(host) = uname.nodename().to_str()
+        && !host.is_empty()
+        && host != "localhost"
+    {
+        sans.push(host.to_string());
+        if !host.contains('.') {
+            sans.push(format!("{host}.local"));
+        }
+    }
+    sans
+}
+
+fn build_self_signed(key: &PKey<Private>, sans: &[String]) -> anyhow::Result<X509> {
+    let mut name = X509NameBuilder::new()?;
+    name.append_entry_by_nid(Nid::COMMONNAME, "varlink-httpd")?;
+    let name = name.build();
+
+    let mut builder = X509::builder()?;
+    builder.set_version(2)?; // X.509 v3
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?;
+    builder.set_pubkey(key)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    let not_after = Asn1Time::days_from_now(VALIDITY_DAYS)?;
+    builder.set_not_before(&not_before)?;
+    builder.set_not_after(&not_after)?;
+
+    let mut serial = BigNum::new()?;
+    serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+    let serial = serial.to_asn1_integer()?;
+    builder.set_serial_number(&serial)?;
+
+    builder.append_extension(BasicConstraints::new().critical().build()?)?;
+    builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .digital_signature()
+            .key_encipherment()
+            .build()?,
+    )?;
+    builder.append_extension(ExtendedKeyUsage::new().server_auth().build()?)?;
+
+    let mut san = SubjectAlternativeName::new();
+    for entry in sans {
+        if entry.parse::<std::net::IpAddr>().is_ok() {
+            san.ip(entry);
+        } else {
+            san.dns(entry);
+        }
+    }
+    let ctx = builder.x509v3_context(None, None);
+    builder.append_extension(san.build(&ctx)?)?;
+
+    builder.sign(key, MessageDigest::sha256())?;
+    Ok(builder.build())
+}
+
+pub(crate) fn state_dir() -> anyhow::Result<PathBuf> {
+    if let Some(d) = std::env::var_os("STATE_DIRECTORY") {
+        return Ok(PathBuf::from(d));
+    }
+    if let Some(d) = std::env::var_os("XDG_STATE_HOME") {
+        return Ok(PathBuf::from(d).join("varlink-httpd"));
+    }
+    let home = std::env::var_os("HOME")
+        .context("none of STATE_DIRECTORY, XDG_STATE_HOME or HOME is set")?;
+    Ok(PathBuf::from(home).join(".local/state/varlink-httpd"))
+}
+
+/// Write `contents` to `path` atomically with `mode`.
+fn write_private(path: &Path, contents: &[u8], mode: u32) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let dir = path.parent().context("path has no parent directory")?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)
+        .with_context(|| format!("creating tempfile in {}", dir.display()))?;
+    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(mode))
+        .with_context(|| format!("setting mode {mode:o} on tempfile for {}", path.display()))?;
+    tmp.write_all(contents)
+        .with_context(|| format!("writing {}", path.display()))?;
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("syncing {}", path.display()))?;
+    tmp.persist(path)
+        .with_context(|| format!("renaming tempfile to {}", path.display()))?;
+    Ok(())
+}
+
+/// Load the persisted self-signed certificate, or create one if absent.
+pub(crate) fn load_or_generate(dir: &Path) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let (cert_path, key_path) = (dir.join("server-cert.pem"), dir.join("server-key.pem"));
+
+    match (cert_path.exists(), key_path.exists()) {
+        (true, true) => {
+            let mode = std::fs::metadata(&key_path)
+                .with_context(|| format!("stat {}", key_path.display()))?
+                .permissions()
+                .mode()
+                & 0o777;
+            // reject group/other access only, so 0400 is as fine as 0600
+            if mode & 0o077 != 0 {
+                bail!(
+                    "refusing to use generated TLS key {}: permissions are 0{mode:o}, must not be group- or world-accessible",
+                    key_path.display()
+                );
+            }
+            return Ok((cert_path, key_path));
+        }
+        (false, false) => {}
+        // Regenerating would silently invalidate every client pin, so leave
+        // a half-written pair to the operator.
+        _ => bail!(
+            "incomplete generated TLS material in {}: expected both {} and {}",
+            dir.display(),
+            cert_path.display(),
+            key_path.display()
+        ),
+    }
+
+    let sans = default_sans();
+    let key = generate_keypair()?;
+    let cert = build_self_signed(&key, &sans)?;
+
+    write_private(
+        &key_path,
+        &key.private_key_to_pem_pkcs8()
+            .context("encoding private key")?,
+        0o600,
+    )?;
+    write_private(
+        &cert_path,
+        &cert.to_pem().context("encoding certificate")?,
+        0o644,
+    )?;
+
+    eprintln!(
+        "TLS: generated self-signed certificate {} (SAN: {})",
+        cert_path.display(),
+        sans.join(", ")
+    );
+    Ok((cert_path, key_path))
+}
+
+/// Announce the pin clients must verify the server against: what
+/// `varlinkctl-http` records in `known-hosts`, and what curl takes via
+/// `--pinnedpubkey`.
+pub(crate) fn print_pin(cert_path: &Path) -> anyhow::Result<()> {
+    let pem =
+        std::fs::read(cert_path).with_context(|| format!("reading {}", cert_path.display()))?;
+    let cert = X509::from_pem(&pem).with_context(|| format!("parsing {}", cert_path.display()))?;
+    let pin = varlink_http_bridge::public_key_pin(&cert)?;
+    eprintln!("TLS: using self-signed certificate, pin clients to sha256//{pin}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmpdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn generates_a_usable_pair_on_first_run() {
+        let dir = tmpdir();
+        let (cert_path, key_path) = load_or_generate(dir.path()).unwrap();
+        assert!(cert_path.exists() && key_path.exists());
+
+        // the pair must actually load as a TLS server identity
+        crate::load_tls_acceptor(
+            cert_path.to_str().unwrap(),
+            key_path.to_str().unwrap(),
+            None,
+        )
+        .expect("generated material must build an acceptor");
+    }
+
+    #[test]
+    fn key_is_written_0600_and_cert_world_readable() {
+        let dir = tmpdir();
+        let (cert_path, key_path) = load_or_generate(dir.path()).unwrap();
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&key_path), 0o600);
+        assert_eq!(mode(&cert_path), 0o644);
+    }
+
+    #[test]
+    fn second_run_reuses_the_same_key_so_pins_survive() {
+        let dir = tmpdir();
+        let (cert_a, _) = load_or_generate(dir.path()).unwrap();
+        let pin_a = varlink_http_bridge::public_key_pin(
+            &X509::from_pem(&std::fs::read(&cert_a).unwrap()).unwrap(),
+        )
+        .unwrap();
+
+        let (cert_b, _) = load_or_generate(dir.path()).unwrap();
+        let pin_b = varlink_http_bridge::public_key_pin(
+            &X509::from_pem(&std::fs::read(&cert_b).unwrap()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(pin_a, pin_b, "regeneration must not invalidate client pins");
+    }
+
+    #[test]
+    fn refuses_a_half_written_pair() {
+        let dir = tmpdir();
+        let (cert_path, key_path) = load_or_generate(dir.path()).unwrap();
+        std::fs::remove_file(&key_path).unwrap();
+
+        let err = load_or_generate(dir.path()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("incomplete"),
+            "expected an incomplete-material error, got: {err:#}"
+        );
+        assert!(cert_path.exists(), "the surviving half must be left alone");
+    }
+
+    #[test]
+    fn refuses_a_world_readable_key() {
+        let dir = tmpdir();
+        let (_, key_path) = load_or_generate(dir.path()).unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = load_or_generate(dir.path()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("0644"),
+            "expected a permissions error naming the mode, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn cert_carries_the_loopback_sans() {
+        let dir = tmpdir();
+        let (cert_path, _) = load_or_generate(dir.path()).unwrap();
+        let cert = X509::from_pem(&std::fs::read(cert_path).unwrap()).unwrap();
+        let san = cert.subject_alt_names().expect("cert must carry SANs");
+        let dns: Vec<String> = san
+            .iter()
+            .filter_map(|n| n.dnsname().map(String::from))
+            .collect();
+        assert!(
+            dns.contains(&"localhost".to_string()),
+            "got DNS SANs {dns:?}"
+        );
+        assert!(
+            san.iter().any(|n| n.ipaddress().is_some()),
+            "loopback IP SANs must be present"
+        );
+    }
+}

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 use std::os::fd::BorrowedFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use futures_util::{SinkExt, StreamExt};
 use log::{debug, warn};
-use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVersion};
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode, SslVersion};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::signal::unix::{SignalKind, signal};
@@ -35,24 +36,195 @@ const CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 // WebSocket upgrade.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Build an `SslConnector` with client certs and a custom CA loaded from the
-/// first existing directory:
+/// Candidate client configuration directories, most specific first:
 /// 1. `$XDG_CONFIG_HOME/varlinkctl-http/`
 /// 2. `~/.config/varlinkctl-http/`
 /// 3. `/etc/varlinkctl-http/`
-fn build_ssl_connector() -> Result<SslConnector> {
+fn config_dirs() -> Vec<PathBuf> {
+    [
+        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlinkctl-http")),
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlinkctl-http")),
+        Some(PathBuf::from("/etc/varlinkctl-http")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// First [`config_dirs`] entry that exists.
+fn config_dir() -> Option<PathBuf> {
+    config_dirs().into_iter().find(|d| d.is_dir())
+}
+
+/// What `known-hosts` records about a peer.
+#[derive(Debug, PartialEq, Eq)]
+enum KnownHost {
+    /// Pinned public key of a self-signed server. Trust on first use, pin to
+    /// ensure we are talking to the same system on second contact.
+    /// Written as the `sha256//…` the daemon prints on startup, so an operator
+    /// can paste an entry in ahead of time.
+    Pin(String),
+    /// A trust authority vouched for this peer. No key is pinned, so the
+    /// server stays free to rotate its key. Recorded so we don't fall back
+    /// to trust a self-sigend cert for the server in a later contact.
+    TrustAuthority,
+}
+
+impl KnownHost {
+    /// Parse a recorded value; `None` if the line carries none.
+    fn parse(value: &str) -> Option<Self> {
+        if value == "ca" {
+            return Some(Self::TrustAuthority);
+        }
+        let pin = value.strip_prefix("sha256//").unwrap_or(value);
+        (!pin.is_empty()).then(|| Self::Pin(pin.to_string()))
+    }
+}
+
+/// The value as written to `known-hosts`; the inverse of [`KnownHost::parse`].
+impl std::fmt::Display for KnownHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pin(pin) => write!(f, "sha256//{pin}"),
+            Self::TrustAuthority => f.write_str("ca"),
+        }
+    }
+}
+
+/// What is known about each server, one [`KnownHost`] per line:
+///
+/// ```text
+/// myserver:1031   sha256//SHPiyqubI9L9Nor4n+SKT5CodBou6KDBMeyJlTib/38=
+/// otherhost:1031  ca
+/// ```
+fn known_hosts_path() -> Option<PathBuf> {
+    let dirs = config_dirs();
+    let dir = dirs.iter().find(|d| d.is_dir()).or(dirs.first())?;
+    Some(dir.join("known-hosts"))
+}
+
+/// What is recorded for `peer` in the `known-hosts` file at `path`.
+fn lookup_known_host(path: &Path, peer: &str) -> Result<Option<KnownHost>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    for line in text.lines() {
+        let line = line
+            .split_once('#')
+            .map_or(line, |(before, _)| before)
+            .trim();
+        let Some((host, value)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        if host == peer {
+            let known = KnownHost::parse(value.trim())
+                .with_context(|| format!("{}: empty value recorded for {peer}", path.display()))?;
+            return Ok(Some(known));
+        }
+    }
+    Ok(None)
+}
+
+/// Append what `peer` proved on first contact to the `known-hosts` file.
+fn record_known_host(path: &Path, peer: &str, host: &KnownHost) -> Result<()> {
+    use std::io::Write as _;
+
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    writeln!(f, "{peer}\t{host}").with_context(|| format!("writing {}", path.display()))?;
+
+    match host {
+        KnownHost::Pin(_) => warn!(
+            "{peer}: no key recorded, trusting the one presented on first contact. \
+             Recorded {host} in {}.",
+            path.display()
+        ),
+        KnownHost::TrustAuthority => debug!(
+            "{peer}: recorded as vouched for by a trust authority in {}.",
+            path.display()
+        ),
+    }
+    Ok(())
+}
+
+/// Whether the certificate names itself as its own issuer.
+fn is_self_signed(cert: &openssl::x509::X509Ref) -> bool {
+    cert.issuer_name()
+        .try_cmp(cert.subject_name())
+        .is_ok_and(std::cmp::Ordering::is_eq)
+}
+
+/// Decide whether the server's certificate is acceptable.
+///
+/// PKI is the real signal, so a validated certificate is always accepted, and
+/// `known-hosts` only governs the certificates nothing vouches for. Accepting
+/// early is also what lets a [`KnownHost::TrustAuthority`] peer rotate its
+/// key: the new certificate validates and never reaches the rules below.
+///
+/// The refusal reason is a message, not an error, because the OpenSSL verify
+/// callback can only answer yes or no and stores it for the caller.
+fn verify_server_cert(
+    cert: &openssl::x509::X509Ref,
+    chain_ok: bool,
+    recorded: Option<&KnownHost>,
+    ca_configured: bool,
+) -> Result<(), &'static str> {
+    if chain_ok {
+        // A stale pin is left alone; it still catches a later downgrade.
+        return Ok(());
+    }
+    if ca_configured {
+        return Err("certificate does not validate against the configured server-ca-file");
+    }
+    if !is_self_signed(cert) {
+        return Err("certificate does not validate against trust authority");
+    }
+
+    match recorded {
+        // No record yet: first contact, connect_tls learns the key afterwards.
+        None => Ok(()),
+        Some(KnownHost::TrustAuthority) => Err(
+            "this peer was reached before with a certificate signed by a trust authority \
+             and now presents a self-signed one. Refusing the downgrade. If the server \
+             really stopped using a CA cert, delete its known-hosts line.",
+        ),
+        Some(KnownHost::Pin(pin)) => {
+            let actual = varlink_http_bridge::public_key_pin(cert)
+                .map_err(|_| "cannot fingerprint the server key")?;
+            if *pin != actual {
+                return Err(
+                    "the server key does not match the one recorded in known-hosts. \
+                     Either the server was reinstalled, or this is not the same server.",
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Build an `SslConnector` with client certs and the system trust store.
+///
+/// Any refusal reason lands in `refusal`; OpenSSL drops the peer certificate
+/// when it aborts, so the caller cannot work it out afterwards.
+fn build_ssl_connector(
+    recorded: Option<KnownHost>,
+    ca_configured: bool,
+    refusal: Arc<OnceLock<&'static str>>,
+) -> Result<SslConnector> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
     // We need tls channel binding per RFC 9266 ("tls-exporter") which
     // is only guaranteed unique with TLS 1.3.
     builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
 
-    let config_dirs = [
-        std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlinkctl-http")),
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/varlinkctl-http")),
-        Some(PathBuf::from("/etc/varlinkctl-http")),
-    ];
-
-    if let Some(dir) = config_dirs.into_iter().flatten().find(|d| d.is_dir()) {
+    if let Some(dir) = config_dir() {
         let cert = dir.join("client-cert-file");
         let key = dir.join("client-key-file");
         let ca = dir.join("server-ca-file");
@@ -76,28 +248,71 @@ fn build_ssl_connector() -> Result<SslConnector> {
         }
     }
 
+    builder.set_verify_callback(SslVerifyMode::PEER, move |chain_ok, ctx| {
+        // errors above the leaf abort on their own
+        if ctx.error_depth() != 0 {
+            return chain_ok;
+        }
+        let Some(cert) = ctx.current_cert() else {
+            return false;
+        };
+        match verify_server_cert(cert, chain_ok, recorded.as_ref(), ca_configured) {
+            Ok(()) => true,
+            Err(why) => {
+                let _ = refusal.set(why);
+                false
+            }
+        }
+    });
+
     Ok(builder.build())
 }
 
 /// TLS-handshake `stream`, returning it with the RFC 9266 channel binding.
 ///
+/// `peer` identifies the server in `known-hosts` and must be stable and
+/// unique per endpoint (`host:port`, or `vsock:CID:PORT`).
+///
 /// `verify_hostname=false` is for vsock where there is no hostname; the
 /// peer certificate is still verified against the CA chain.
 async fn connect_tls<S: AsyncStream + 'static>(
+    peer: &str,
     domain: &str,
     verify_hostname: bool,
     stream: S,
     error_context: &'static str,
 ) -> Result<(BoxedStream, Option<TlsChannelBinding>)> {
-    let connector = build_ssl_connector()?;
+    let known_hosts = known_hosts_path().context("no configuration directory for known-hosts")?;
+    let recorded = lookup_known_host(&known_hosts, peer)?;
+    let first_contact = recorded.is_none();
+    let ca_configured = config_dir().is_some_and(|d| d.join("server-ca-file").exists());
+
+    let refusal = Arc::new(OnceLock::new());
+    let connector = build_ssl_connector(recorded, ca_configured, Arc::clone(&refusal))?;
     let mut config = connector.configure().context("SSL configure")?;
+    // Left on so CA-issued certificates are still name-checked; self-signed
+    // ones fail here too, which verify_server_cert tolerates.
     config.set_verify_hostname(verify_hostname);
     let ssl = config.into_ssl(domain).context("SSL setup")?;
     let mut tls_stream = tokio_openssl::SslStream::new(ssl, stream)?;
-    Pin::new(&mut tls_stream)
-        .connect()
-        .await
-        .context(error_context)?;
+
+    if let Err(e) = Pin::new(&mut tls_stream).connect().await {
+        return Err(anyhow::Error::new(e).context(match refusal.get() {
+            Some(why) => format!("{peer}: {why}"),
+            None => error_context.to_string(),
+        }));
+    }
+
+    if first_contact && let Some(cert) = tls_stream.ssl().peer_certificate() {
+        let observed = if tls_stream.ssl().verify_result() == openssl::x509::X509VerifyResult::OK {
+            KnownHost::TrustAuthority
+        } else {
+            KnownHost::Pin(varlink_http_bridge::public_key_pin(&cert)?)
+        };
+        record_known_host(&known_hosts, peer, &observed)
+            .with_context(|| format!("recording what {peer} presented"))?;
+    }
+
     let tls_channel_binding = varlink_http_bridge::export_tls_channel_binding(tls_stream.ssl());
     Ok((Box::new(tls_stream), Some(tls_channel_binding)))
 }
@@ -132,6 +347,7 @@ async fn connect_vsock(
 
     if use_tls {
         let (stream, tls_channel_binding) = connect_tls(
+            &format!("vsock:{cid}:{port}"),
             "vsock",
             false,
             raw_stream,
@@ -172,6 +388,7 @@ async fn connect_tcp(url: &str) -> Result<(BoxedStream, String, Option<TlsChanne
 
     if use_tls {
         let (stream, tls_channel_binding) = connect_tls(
+            &format!("{host}:{port}"),
             &host,
             true,
             tcp,
@@ -387,6 +604,231 @@ async fn main() -> Result<()> {
         .with_context(|| format!("timed out connecting to '{bridge_url}'"))??;
 
     run_proxy(ws, fd3).await
+}
+
+#[cfg(test)]
+mod pin_tests {
+    use super::*;
+    use openssl::ssl::SslAcceptor;
+
+    #[test]
+    fn known_hosts_lookup_is_per_peer_and_tolerates_formatting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("known-hosts");
+        assert_eq!(lookup_known_host(&path, "a:1031").unwrap(), None);
+
+        std::fs::write(
+            &path,
+            "# a comment\n\
+             a:1031\tsha256//AAAA=\n\
+             b:1031   BBBB=\n\
+             \n\
+             c:1031 sha256//CCCC= # trailing comment\n\
+             d:1031\tca\n",
+        )
+        .unwrap();
+
+        let pin = |s: &str| KnownHost::Pin(s.to_string());
+        // the daemon's own output pastes in verbatim, prefix and all
+        assert_eq!(
+            lookup_known_host(&path, "a:1031").unwrap(),
+            Some(pin("AAAA="))
+        );
+        // ...and a bare value works too
+        assert_eq!(
+            lookup_known_host(&path, "b:1031").unwrap(),
+            Some(pin("BBBB="))
+        );
+        assert_eq!(
+            lookup_known_host(&path, "c:1031").unwrap(),
+            Some(pin("CCCC="))
+        );
+        // the marker for a peer a trust authority vouched for
+        assert_eq!(
+            lookup_known_host(&path, "d:1031").unwrap(),
+            Some(KnownHost::TrustAuthority)
+        );
+        // a different port is a different peer
+        assert_eq!(lookup_known_host(&path, "a:1032").unwrap(), None);
+    }
+
+    #[test]
+    fn recorded_entries_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("known-hosts");
+        let entries = [
+            ("host:1031", KnownHost::Pin("AAAA=".to_string())),
+            ("other:1031", KnownHost::Pin("BBBB=".to_string())),
+            ("ca-backed:1031", KnownHost::TrustAuthority),
+        ];
+        for (peer, host) in &entries {
+            record_known_host(&path, peer, host).unwrap();
+        }
+        for (peer, host) in &entries {
+            assert_eq!(lookup_known_host(&path, peer).unwrap().as_ref(), Some(host));
+        }
+    }
+
+    type Identity = (
+        openssl::x509::X509,
+        openssl::pkey::PKey<openssl::pkey::Private>,
+    );
+
+    /// A throwaway identity. Given an `issuer` the certificate is signed by
+    /// it and so is not self-signed; without one it signs itself.
+    fn identity(cn: &str, issuer: Option<&Identity>, is_ca: bool) -> Identity {
+        use openssl::{asn1::Asn1Time, ec, hash::MessageDigest, nid::Nid, pkey::PKey, x509};
+
+        let group = ec::EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let key = PKey::from_ec_key(ec::EcKey::generate(&group).unwrap()).unwrap();
+
+        let mut nb = x509::X509NameBuilder::new().unwrap();
+        nb.append_entry_by_nid(Nid::COMMONNAME, cn).unwrap();
+        let name = nb.build();
+
+        let mut b = x509::X509::builder().unwrap();
+        b.set_version(2).unwrap();
+        b.set_subject_name(&name).unwrap();
+        match issuer {
+            Some((cert, _)) => b.set_issuer_name(cert.subject_name()).unwrap(),
+            None => b.set_issuer_name(&name).unwrap(),
+        }
+        b.set_pubkey(&key).unwrap();
+        b.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        b.set_not_after(&Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        if is_ca {
+            b.append_extension(
+                x509::extension::BasicConstraints::new()
+                    .critical()
+                    .ca()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        }
+        b.sign(issuer.map_or(&key, |(_, k)| k), MessageDigest::sha256())
+            .unwrap();
+        (b.build(), key)
+    }
+
+    /// Rejecting inside the verify callback must abort before we send our own
+    /// certificate; rejecting after the handshake would already have leaked it.
+    #[tokio::test]
+    async fn a_refused_server_never_sees_our_client_certificate() {
+        for reject in [true, false] {
+            let server = identity("srv", None, false);
+            let client = identity("cli", None, false);
+
+            let mut acceptor = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server()).unwrap();
+            acceptor.set_certificate(&server.0).unwrap();
+            acceptor.set_private_key(&server.1).unwrap();
+            acceptor.set_verify_callback(SslVerifyMode::PEER, |_ok, _ctx| true);
+            let acceptor = acceptor.build();
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(async move {
+                let (stream, _) = listener.accept().await.unwrap();
+                let ssl = openssl::ssl::Ssl::new(acceptor.context()).unwrap();
+                let mut tls = tokio_openssl::SslStream::new(ssl, stream).unwrap();
+                let _ = Pin::new(&mut tls).accept().await;
+                let _ = tx.send(tls.ssl().peer_certificate().is_some());
+            });
+
+            let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            let mut b = SslConnector::builder(SslMethod::tls_client()).unwrap();
+            b.set_min_proto_version(Some(SslVersion::TLS1_3)).unwrap();
+            b.set_certificate(&client.0).unwrap();
+            b.set_private_key(&client.1).unwrap();
+            b.set_verify_callback(SslVerifyMode::PEER, move |_ok, _ctx| !reject);
+            let mut cfg = b.build().configure().unwrap();
+            cfg.set_verify_hostname(false);
+            let ssl = cfg.into_ssl("srv").unwrap();
+            let mut tls = tokio_openssl::SslStream::new(ssl, stream).unwrap();
+            let handshake = Pin::new(&mut tls).connect().await;
+
+            let saw_client_cert = tokio::time::timeout(Duration::from_secs(5), rx)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(handshake.is_err(), reject);
+            assert_eq!(
+                saw_client_cert, !reject,
+                "reject={reject}: the server must only see our certificate when we accept it"
+            );
+        }
+    }
+
+    fn self_signed_pin() -> (Identity, String) {
+        let id = identity("leaf", None, false);
+        let pin = varlink_http_bridge::public_key_pin(&id.0).unwrap();
+        (id, pin)
+    }
+
+    #[test]
+    fn a_validated_chain_wins_and_known_hosts_is_not_consulted() {
+        let (id, _) = self_signed_pin();
+        // a deliberately wrong recorded key must not veto the CA
+        let wrong = KnownHost::Pin("AAAA=".to_string());
+        assert!(verify_server_cert(&id.0, true, Some(&wrong), false).is_ok());
+    }
+
+    #[test]
+    fn an_unprovable_issuer_is_refused_even_with_a_recorded_key() {
+        let ca = identity("ca", None, true);
+        let leaf = identity("leaf", Some(&ca), false);
+        let pin = KnownHost::Pin(varlink_http_bridge::public_key_pin(&leaf.0).unwrap());
+        let err = verify_server_cert(&leaf.0, false, Some(&pin), false).unwrap_err();
+        assert!(err.contains("does not validate"), "{err}");
+    }
+
+    #[test]
+    fn self_signed_is_governed_by_known_hosts() {
+        let (id, pin) = self_signed_pin();
+        // first contact, connect_tls records afterwards
+        assert!(verify_server_cert(&id.0, false, None, false).is_ok());
+        let recorded = KnownHost::Pin(pin);
+        assert!(verify_server_cert(&id.0, false, Some(&recorded), false).is_ok());
+        let wrong = KnownHost::Pin("AAAA=".to_string());
+        let err = verify_server_cert(&id.0, false, Some(&wrong), false).unwrap_err();
+        assert!(err.contains("does not match"), "{err}");
+    }
+
+    /// The downgrade the `ca` record exists to catch: a peer only ever reached
+    /// with a certificate a trust authority vouched for must not be allowed to
+    /// turn up self-signed, even though no key was ever pinned for it.
+    #[test]
+    fn a_ca_backed_peer_refuses_a_later_self_signed_certificate() {
+        let (id, _) = self_signed_pin();
+        let err =
+            verify_server_cert(&id.0, false, Some(&KnownHost::TrustAuthority), false).unwrap_err();
+        assert!(err.contains("Refusing the downgrade"), "{err}");
+    }
+
+    /// ...while pinning no key, so the server stays free to rotate as long as
+    /// what it presents still validates.
+    #[test]
+    fn a_ca_backed_peer_may_rotate_its_key() {
+        let ca = identity("ca", None, true);
+        for cn in ["leaf", "leaf-after-rotation"] {
+            // a fresh keypair each time round, so this is a real rotation
+            let leaf = identity(cn, Some(&ca), false);
+            assert!(
+                verify_server_cert(&leaf.0, true, Some(&KnownHost::TrustAuthority), false).is_ok(),
+                "{cn} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn a_configured_ca_disables_first_contact_trust() {
+        let (id, _) = self_signed_pin();
+        let err = verify_server_cert(&id.0, false, None, true).unwrap_err();
+        assert!(err.contains("server-ca-file"), "{err}");
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,27 @@ pub fn parse_vsock_cid_port(authority: &str) -> anyhow::Result<(u32, u32)> {
     }
 }
 
+/// Fingerprint of a certificate's public key: base64 of the SHA-256 digest
+/// of the DER-encoded `SubjectPublicKeyInfo`.
+///
+/// httpd prints it if a self-signed cert is used, and the client pins against it.
+/// The encoding matches what `curl --pinnedpubkey sha256//…` expects.
+///
+/// # Errors
+/// Returns an error if the key cannot be extracted or DER-encoded.
+pub fn public_key_pin(cert: &openssl::x509::X509Ref) -> anyhow::Result<String> {
+    use anyhow::Context;
+
+    let spki = cert
+        .public_key()
+        .context("reading certificate public key")?
+        .public_key_to_der()
+        .context("encoding SubjectPublicKeyInfo")?;
+    let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), &spki)
+        .context("hashing SubjectPublicKeyInfo")?;
+    Ok(openssl::base64::encode_block(&digest))
+}
+
 /// TLS channel binding label per RFC 9266 (`tls-exporter`).
 ///
 /// Both client and server call `export_keying_material()` with this label


### PR DESCRIPTION
No longer fall back to plain HTTP: instead let the bridge generate a self-signed cert when no --cert/--key is given and persist it in the state dir. SANs use defaults, the more useful mechanism for users in this mode is to pin the public key of the server.

varlinkctl-http learns that key on first contact, records it in a known-hosts file and refuses later connections presenting a different one. PKI stays authoritative: a CA-validated certificate is accepted without consulting known-hosts.