### PR TITLE
httpd: improve messages for unread creds and handling of unusable CA files

### DIFF
--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1701,12 +1701,11 @@ fn parse_import_ssh_args(parser: &mut lexopt::Parser) -> anyhow::Result<Command>
     Ok(Command::ImportSsh(import_ssh::ImportSsh { source, output }))
 }
 
-/// Credentials present in `creds_dir` that this configuration never reads,
-/// paired with what would make them count.
+/// Credentials present in `creds_dir` that are unused due to flag usage.
 ///
-/// Enabling a mechanism from the mere presence of a credential would mean one
-/// that fails to show up silently drops it, so the flags decide and provisioned
-/// material can go unread. That is easy to mistake for having taken effect.
+/// Credentials don't enable mechanisms implicitly, and concrete flag values
+/// take precedence over credentials. The returned list contains unused credentials
+/// and why they aren't used so we can warn about potential misconfiguration.
 fn unread_credentials(creds_dir: &std::path::Path, cli: &BridgeCli) -> Vec<(String, &'static str)> {
     let mut unread = Vec::new();
 

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -501,6 +501,15 @@ struct TrustCache {
     cas: Vec<openssl::x509::X509>,
 }
 
+/// Read the CA certificates in `path`. Errors carry no path context, callers
+/// name the file themselves.
+///
+/// An `Ok` empty vector means the file parsed but held no certificate.
+fn read_client_cas(path: &std::path::Path) -> anyhow::Result<Vec<openssl::x509::X509>> {
+    let pem = std::fs::read(path)?;
+    Ok(openssl::x509::X509::stack_from_pem(&pem)?)
+}
+
 impl ClientTrust {
     fn new(path: Option<&str>) -> Self {
         let trust = Self {
@@ -528,9 +537,9 @@ impl ClientTrust {
         trust
     }
 
-    /// Re-read the CA file when its mtime changed. A file that cannot be read
-    /// or parsed keeps the previous CAs and leaves the mtime alone, so the
-    /// next connection retries; a file that is gone drops them.
+    /// Re-read the CA file when its mtime changed. Removing the file drops the CAs.
+    /// An unparseable or empty file keeps the previous CAs and leaves the mtime untouched
+    /// so the next connection retries.
     fn maybe_reload(&self) {
         let Some(path) = self.path.as_deref() else {
             return;
@@ -563,28 +572,19 @@ impl ClientTrust {
             return;
         };
 
-        match std::fs::read(path)
-            .map_err(anyhow::Error::from)
-            .and_then(|pem| Ok(openssl::x509::X509::stack_from_pem(&pem)?))
-        {
-            Ok(cas) if cas.is_empty() => {
-                warn!(
-                    "no certificates in {}, mTLS will reject every client",
-                    path.display()
-                );
-                *cache = TrustCache {
-                    mtime: Some(mtime),
-                    cas,
-                };
-            }
-            Ok(cas) => {
+        match read_client_cas(path) {
+            Ok(cas) if !cas.is_empty() => {
                 info!("loaded {} client CA(s) from {}", cas.len(), path.display());
                 *cache = TrustCache {
                     mtime: Some(mtime),
                     cas,
                 };
             }
-            // Leave mtime untouched so the next connection tries again.
+            Ok(_) => warn!(
+                "empty or corrupt certificate file {}, keeping cached client CAs \
+                 (remove the file to withdraw trust)",
+                path.display()
+            ),
             Err(e) => warn!(
                 "cannot load {}: {e:#}, keeping cached client CAs",
                 path.display()
@@ -1627,6 +1627,14 @@ fn parse_cli() -> anyhow::Result<Command> {
             if set {
                 bail!("--insecure serves plain HTTP and can't be combined with {name}");
             }
+        }
+    }
+
+    if let Some(path) = trust.as_deref() {
+        let cas = read_client_cas(std::path::Path::new(path))
+            .with_context(|| format!("--trust={path}"))?;
+        if cas.is_empty() {
+            bail!("--trust={path} holds no certificate");
         }
     }
 

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1701,13 +1701,14 @@ fn parse_import_ssh_args(parser: &mut lexopt::Parser) -> anyhow::Result<Command>
     Ok(Command::ImportSsh(import_ssh::ImportSsh { source, output }))
 }
 
-/// Credentials present in `creds_dir` that are unused due to flag usage.
+/// Warns about credentials present in `creds_dir` that are unused due to flag
+/// usage, or `None` when every credential present is read.
 ///
 /// Credentials don't enable mechanisms implicitly, and concrete flag values
-/// take precedence over credentials. The returned list contains unused credentials
-/// and why they aren't used so we can warn about potential misconfiguration.
-fn unread_credentials(creds_dir: &std::path::Path, cli: &BridgeCli) -> Vec<(String, &'static str)> {
-    let mut unread = Vec::new();
+/// take precedence over credentials. The warning names the unused credentials
+/// and why they aren't used so we can point at potential misconfiguration.
+fn unread_credentials_warning(creds_dir: &std::path::Path, cli: &BridgeCli) -> Option<String> {
+    let mut unread: Vec<String> = Vec::new();
 
     for (name, read, why, explicit) in [
         (
@@ -1744,7 +1745,7 @@ fn unread_credentials(creds_dir: &std::path::Path, cli: &BridgeCli) -> Vec<(Stri
             None
         };
         if let Some(why) = why {
-            unread.push((name.to_string(), why));
+            unread.push(format!("{name} ({why})"));
         }
     }
 
@@ -1763,12 +1764,18 @@ fn unread_credentials(creds_dir: &std::path::Path, cli: &BridgeCli) -> Vec<(Stri
             unread.extend(
                 auth_ssh::authorized_keys_credentials(creds_dir)
                     .into_iter()
-                    .map(|name| (name, why)),
+                    .map(|name| format!("{name} ({why})")),
             );
         }
     }
 
-    unread
+    if unread.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "credential(s) present but unused by this configuration: {}",
+        unread.join("; ")
+    ))
 }
 
 /// The middleware accepts a request as soon as one of these accepts it, so an
@@ -1833,17 +1840,10 @@ async fn main() -> anyhow::Result<()> {
 
     let creds_dir = varlink_http_bridge::sysconf::CredentialsLoader::path_from_env();
 
-    if let Some(dir) = creds_dir.as_deref() {
-        let unread: Vec<String> = unread_credentials(dir, &cli)
-            .iter()
-            .map(|(name, why)| format!("{name} ({why})"))
-            .collect();
-        if !unread.is_empty() {
-            warn!(
-                "credential(s) present but unused by this configuration: {}",
-                unread.join("; ")
-            );
-        }
+    if let Some(dir) = creds_dir.as_deref()
+        && let Some(warning) = unread_credentials_warning(dir, &cli)
+    {
+        warn!("{warning}");
     }
 
     let authenticators = build_authenticators(

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1699,22 +1699,44 @@ fn parse_import_ssh_args(parser: &mut lexopt::Parser) -> anyhow::Result<Command>
 /// Enabling a mechanism from the mere presence of a credential would mean one
 /// that fails to show up silently drops it, so the flags decide and provisioned
 /// material can go unread. That is easy to mistake for having taken effect.
-#[cfg_attr(not(feature = "sshauth"), allow(unused_variables))]
-fn unread_credentials(
-    creds_dir: &std::path::Path,
-    insecure: bool,
-    require_mtls: bool,
-    auth: &[AuthMechanism],
-    authorized_keys: Option<&str>,
-) -> Vec<(String, &'static str)> {
+fn unread_credentials(creds_dir: &std::path::Path, cli: &BridgeCli) -> Vec<(String, &'static str)> {
     let mut unread = Vec::new();
 
-    for (name, read, why) in [
-        ("cert", !insecure, "--insecure serves plain HTTP"),
-        ("key", !insecure, "--insecure serves plain HTTP"),
-        ("trust", require_mtls, "pass --require-mtls to enable mTLS"),
+    for (name, read, why, explicit) in [
+        (
+            "cert",
+            !cli.insecure,
+            "--insecure serves plain HTTP",
+            cli.cert.is_some(),
+        ),
+        (
+            "key",
+            !cli.insecure,
+            "--insecure serves plain HTTP",
+            cli.key.is_some(),
+        ),
+        (
+            "trust",
+            cli.require_mtls,
+            if cli.insecure {
+                "--insecure serves plain HTTP"
+            } else {
+                "pass --require-mtls to enable mTLS"
+            },
+            cli.trust.is_some(),
+        ),
     ] {
-        if !read && creds_dir.join(name).exists() {
+        if !creds_dir.join(name).exists() {
+            continue;
+        }
+        let why = if !read {
+            Some(why)
+        } else if explicit {
+            Some("an explicit path takes priority")
+        } else {
+            None
+        };
+        if let Some(why) = why {
             unread.push((name.to_string(), why));
         }
     }
@@ -1723,9 +1745,9 @@ fn unread_credentials(
     {
         // An explicit --authorized-keys= replaces discovery rather than adding
         // to it, so it hides credentials even when ssh auth is selected.
-        let why = if authorized_keys.is_some() {
+        let why = if cli.authorized_keys.is_some() {
             Some("--authorized-keys= replaces credential discovery")
-        } else if !auth.contains(&AuthMechanism::Ssh) {
+        } else if !cli.auth.contains(&AuthMechanism::Ssh) {
             Some("pass --auth=ssh to use them")
         } else {
             None
@@ -1805,16 +1827,10 @@ async fn main() -> anyhow::Result<()> {
     let creds_dir = varlink_http_bridge::sysconf::CredentialsLoader::path_from_env();
 
     if let Some(dir) = creds_dir.as_deref() {
-        let unread: Vec<String> = unread_credentials(
-            dir,
-            cli.insecure,
-            cli.require_mtls,
-            &cli.auth,
-            cli.authorized_keys.as_deref(),
-        )
-        .iter()
-        .map(|(name, why)| format!("{name} ({why})"))
-        .collect();
+        let unread: Vec<String> = unread_credentials(dir, &cli)
+            .iter()
+            .map(|(name, why)| format!("{name} ({why})"))
+            .collect();
         if !unread.is_empty() {
             warn!(
                 "credential(s) present but unused by this configuration: {}",

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1221,6 +1221,74 @@ fn test_mtls_watches_trust_credential_before_it_exists() {
     );
 }
 
+/// A file that is still there but yields no CA is a mistake or a refresh
+/// caught mid-write, so the CAs already loaded stay. Removing the file is the
+/// way to withdraw trust, and `test_mtls_trust_reloads_when_ca_appears_and_vanishes`
+/// covers that.
+#[test_with::executable(openssl)]
+#[test]
+fn test_mtls_unusable_trust_file_keeps_the_previous_cas() {
+    let pki = make_test_pki();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("trust");
+
+    std::fs::copy(&pki.ca_cert_path, &path).unwrap();
+    let trust = crate::ClientTrust::new(Some(path.to_str().unwrap()));
+    assert_eq!(trust.store().unwrap().all_certificates().len(), 1);
+
+    for (what, content) in [
+        ("empty", b"".as_slice()),
+        ("not PEM at all", b"nonsense\n"),
+        (
+            "a PEM block that fails to decode",
+            b"-----BEGIN CERTIFICATE-----\nnot base64!!\n-----END CERTIFICATE-----\n",
+        ),
+    ] {
+        std::fs::write(&path, content).unwrap();
+        assert_eq!(
+            trust.store().unwrap().all_certificates().len(),
+            1,
+            "a file that is {what} must keep the CA already loaded"
+        );
+    }
+}
+
+/// A refresh that truncates before writing can be read at zero bytes, and
+/// both halves can fall inside one mtime tick. Caching that read would keep
+/// the stale trust store in place after the real content landed.
+#[test_with::executable(openssl)]
+#[test]
+fn test_mtls_empty_trust_file_is_not_cached() {
+    let pki = make_test_pki();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("trust");
+
+    std::fs::write(&path, b"").unwrap();
+    let trust = crate::ClientTrust::new(Some(path.to_str().unwrap()));
+    assert_eq!(
+        trust.store().unwrap().all_certificates().len(),
+        0,
+        "an empty file must trust nothing"
+    );
+
+    // Rewind the mtime to what the empty read saw, standing in for a write
+    // that lands within the same tick.
+    let mtime = path.metadata().unwrap().modified().unwrap();
+    std::fs::copy(&pki.ca_cert_path, &path).unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(mtime))
+        .unwrap();
+
+    assert_eq!(
+        trust.store().unwrap().all_certificates().len(),
+        1,
+        "the CA that arrived must be picked up, not shadowed by the empty read"
+    );
+}
+
 /// The CA may show up after start, when systemd refreshes credentials on
 /// reload. It has to take effect without restarting the listener, and
 /// removing it again has to take effect just as immediately.

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1662,10 +1662,32 @@ fn unread_names(
     auth: &[AuthMechanism],
     authorized_keys: Option<&str>,
 ) -> Vec<String> {
-    crate::unread_credentials(creds_dir, insecure, require_mtls, auth, authorized_keys)
+    let cli = cli_looking_up_credentials(insecure, require_mtls, auth, authorized_keys);
+    crate::unread_credentials(creds_dir, &cli)
         .into_iter()
         .map(|(name, _)| name)
         .collect()
+}
+
+/// The configuration these tests vary: no path spelled out on the command
+/// line, so every credential is looked up.
+fn cli_looking_up_credentials(
+    insecure: bool,
+    require_mtls: bool,
+    auth: &[AuthMechanism],
+    authorized_keys: Option<&str>,
+) -> crate::BridgeCli {
+    crate::BridgeCli {
+        binds: Vec::new(),
+        varlink_sockets_path: String::new(),
+        cert: None,
+        key: None,
+        trust: None,
+        require_mtls,
+        authorized_keys: authorized_keys.map(String::from),
+        auth: auth.to_vec(),
+        insecure,
+    }
 }
 
 /// Every credential the daemon knows how to read, so each test only has to say
@@ -1703,16 +1725,41 @@ fn test_unread_credentials_reports_trust_without_mtls() {
     assert!(unread.contains(&"trust".to_string()), "{unread:?}");
 }
 
-/// --insecure never reads TLS material at all.
+/// An explicit path replaces credential lookup instead of adding to it, so the
+/// credential goes unread even though mTLS does read one.
 #[test]
-fn test_unread_credentials_reports_tls_material_under_insecure() {
+fn test_unread_credentials_reports_tls_material_hidden_by_explicit_paths() {
     let dir = creds_dir_with_everything();
-    let unread = unread_names(dir.path(), true, false, &[AuthMechanism::None], None);
+    let cli = crate::BridgeCli {
+        cert: Some("/etc/ssl/server.pem".to_string()),
+        key: Some("/etc/ssl/server.key".to_string()),
+        trust: Some("/etc/ssl/ca.pem".to_string()),
+        ..cli_looking_up_credentials(false, true, &[AuthMechanism::None], None)
+    };
+    let unread: Vec<String> = crate::unread_credentials(dir.path(), &cli)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
     for name in ["cert", "key", "trust"] {
         assert!(
             unread.contains(&name.to_string()),
             "{name} missing: {unread:?}"
         );
+    }
+}
+
+/// --insecure never reads TLS material at all.
+#[test]
+fn test_unread_credentials_reports_tls_material_under_insecure() {
+    let dir = creds_dir_with_everything();
+    let cli = cli_looking_up_credentials(true, false, &[AuthMechanism::None], None);
+    let unread = crate::unread_credentials(dir.path(), &cli);
+    for name in ["cert", "key", "trust"] {
+        let (_, why) = unread
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("{name} missing: {unread:?}"));
+        assert!(why.contains("--insecure"), "{name} says: {why}");
     }
 }
 

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1722,20 +1722,26 @@ async fn test_varlinkctl_helper_vsock_hostname_describe() {
 
 // --- unused credential reporting tests ---
 
-/// Just the names, so assertions read as "which credentials go unread".
-fn unread_names(
+/// The warning verbatim, so every assertion below reads like the line a user
+/// finds in the journal.
+fn unread_warning(
     creds_dir: &std::path::Path,
     insecure: bool,
     require_mtls: bool,
     auth: &[AuthMechanism],
     authorized_keys: Option<&str>,
-) -> Vec<String> {
+) -> Option<String> {
     let cli = cli_looking_up_credentials(insecure, require_mtls, auth, authorized_keys);
-    crate::unread_credentials(creds_dir, &cli)
-        .into_iter()
-        .map(|(name, _)| name)
-        .collect()
+    crate::unread_credentials_warning(creds_dir, &cli)
 }
+
+/// `creds_dir_with_everything()` writes ssh credentials too, so a configuration
+/// that doesn't select ssh auth trails them behind whatever else went unread.
+#[cfg(feature = "sshauth")]
+const AND_SSH_KEYS: &str = "; ssh.authorized_keys.root (pass --auth=ssh to use them)\
+     ; varlink-httpd.ssh.authorized-keys.example (pass --auth=ssh to use them)";
+#[cfg(not(feature = "sshauth"))]
+const AND_SSH_KEYS: &str = "";
 
 /// The configuration these tests vary: no path spelled out on the command
 /// line, so every credential is looked up.
@@ -1783,14 +1789,19 @@ fn test_unread_credentials_none_when_all_are_used() {
         #[cfg(not(feature = "sshauth"))]
         AuthMechanism::None,
     ];
-    assert!(unread_names(dir.path(), false, true, &auth, None).is_empty());
+    assert_eq!(unread_warning(dir.path(), false, true, &auth, None), None);
 }
 
 #[test]
 fn test_unread_credentials_reports_trust_without_mtls() {
     let dir = creds_dir_with_everything();
-    let unread = unread_names(dir.path(), false, false, &[AuthMechanism::None], None);
-    assert!(unread.contains(&"trust".to_string()), "{unread:?}");
+    assert_eq!(
+        unread_warning(dir.path(), false, false, &[AuthMechanism::None], None),
+        Some(format!(
+            "credential(s) present but unused by this configuration: \
+             trust (pass --require-mtls to enable mTLS){AND_SSH_KEYS}"
+        ))
+    );
 }
 
 /// An explicit path replaces credential lookup instead of adding to it, so the
@@ -1804,47 +1815,44 @@ fn test_unread_credentials_reports_tls_material_hidden_by_explicit_paths() {
         trust: Some("/etc/ssl/ca.pem".to_string()),
         ..cli_looking_up_credentials(false, true, &[AuthMechanism::None], None)
     };
-    let unread: Vec<String> = crate::unread_credentials(dir.path(), &cli)
-        .into_iter()
-        .map(|(name, _)| name)
-        .collect();
-    for name in ["cert", "key", "trust"] {
-        assert!(
-            unread.contains(&name.to_string()),
-            "{name} missing: {unread:?}"
-        );
-    }
+    assert_eq!(
+        crate::unread_credentials_warning(dir.path(), &cli),
+        Some(format!(
+            "credential(s) present but unused by this configuration: \
+             cert (an explicit path takes priority)\
+             ; key (an explicit path takes priority)\
+             ; trust (an explicit path takes priority){AND_SSH_KEYS}"
+        ))
+    );
 }
 
 /// --insecure never reads TLS material at all.
 #[test]
 fn test_unread_credentials_reports_tls_material_under_insecure() {
     let dir = creds_dir_with_everything();
-    let cli = cli_looking_up_credentials(true, false, &[AuthMechanism::None], None);
-    let unread = crate::unread_credentials(dir.path(), &cli);
-    for name in ["cert", "key", "trust"] {
-        let (_, why) = unread
-            .iter()
-            .find(|(n, _)| n == name)
-            .unwrap_or_else(|| panic!("{name} missing: {unread:?}"));
-        assert!(why.contains("--insecure"), "{name} says: {why}");
-    }
+    assert_eq!(
+        unread_warning(dir.path(), true, false, &[AuthMechanism::None], None),
+        Some(format!(
+            "credential(s) present but unused by this configuration: \
+             cert (--insecure serves plain HTTP)\
+             ; key (--insecure serves plain HTTP)\
+             ; trust (--insecure serves plain HTTP){AND_SSH_KEYS}"
+        ))
+    );
 }
 
 #[cfg(feature = "sshauth")]
 #[test]
 fn test_unread_credentials_reports_ssh_keys_without_ssh_auth() {
     let dir = creds_dir_with_everything();
-    let unread = unread_names(dir.path(), false, true, &[AuthMechanism::None], None);
-    for name in [
-        "ssh.authorized_keys.root",
-        "varlink-httpd.ssh.authorized-keys.example",
-    ] {
-        assert!(
-            unread.contains(&name.to_string()),
-            "{name} missing: {unread:?}"
-        );
-    }
+    assert_eq!(
+        unread_warning(dir.path(), false, true, &[AuthMechanism::None], None).as_deref(),
+        Some(
+            "credential(s) present but unused by this configuration: \
+             ssh.authorized_keys.root (pass --auth=ssh to use them)\
+             ; varlink-httpd.ssh.authorized-keys.example (pass --auth=ssh to use them)"
+        )
+    );
 }
 
 /// An explicit path replaces credential discovery instead of adding to it, so
@@ -1853,23 +1861,31 @@ fn test_unread_credentials_reports_ssh_keys_without_ssh_auth() {
 #[test]
 fn test_unread_credentials_reports_ssh_keys_hidden_by_explicit_path() {
     let dir = creds_dir_with_everything();
-    let unread = unread_names(
+    let unread = unread_warning(
         dir.path(),
         false,
         true,
         &[AuthMechanism::Ssh],
         Some("/etc/varlink-httpd/authorized_keys"),
     );
-    assert!(
-        unread.contains(&"ssh.authorized_keys.root".to_string()),
-        "{unread:?}"
+    assert_eq!(
+        unread.as_deref(),
+        Some(
+            "credential(s) present but unused by this configuration: \
+             ssh.authorized_keys.root (--authorized-keys= replaces credential discovery)\
+             ; varlink-httpd.ssh.authorized-keys.example \
+             (--authorized-keys= replaces credential discovery)"
+        )
     );
 }
 
 #[test]
 fn test_unread_credentials_ignores_absent_files() {
     let dir = tempfile::tempdir().unwrap();
-    assert!(unread_names(dir.path(), true, false, &[AuthMechanism::None], None).is_empty());
+    assert_eq!(
+        unread_warning(dir.path(), true, false, &[AuthMechanism::None], None),
+        None
+    );
 }
 
 // --- --auth= mechanism selection tests ---


### PR DESCRIPTION
Two follow up fixes for #106

Needs further discussion:

The change to caching of trust credential ensures there is a smooth transition from one to the next CA when the file isn't written atomically. However, it means it's not enough to truncate an existing cred to unset the current CA. Also every connection will stat the cred file in case it's content is invalid. **Alternatives to consider:** Keep the old behavior treating an empty file as no CA configured (notice openssl returns empty list even if the file contains garbage), or always fall back to unsetting if the file is empty or unreadable.