### PR TITLE
sshauth: extract shared sshauth_token, add SignedParts struct, require TLS channel binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gethostname",
+ "http",
  "indoc",
  "lexopt",
  "listenfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ test-helpers = []
 anyhow = "1.0.100"
 async-stream = "0.3"
 axum = { version = "0.8.8", features = ["ws"] }
+http = "1"
 futures-core = "0.3"
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "process", "fs", "signal"] }

--- a/README.md
+++ b/README.md
@@ -482,6 +482,11 @@ This is recommended because for websocket requests only the initial
 "upgrade" request is signed with the ssh key, after the upgrade it is
 a plain WebSocket which relies on the underlying TLS for security.
 
+The signed token covers the HTTP method, the path including the query
+string, the `Accept` header, a per-request nonce and the TLS channel
+binding. The request body is not signed, its integrity
+relies on TLS.
+
 
 ## vsock transport
 

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -453,15 +453,14 @@ impl Authenticator for SshKeyAuthenticator {
         let nonce =
             extract_nonce(request.headers).context("missing nonce header (x-auth-nonce)")?;
         let nonce = nonce.as_str();
-        let signed_parts = SignedParts::new(
-            method,
-            path,
-            nonce,
-            request.headers,
-            request.tls_channel_binding,
-        );
-
         let unverified_token = UnverifiedToken::try_from(token_str).context("invalid token")?;
+
+        // sshauth over non-TLS is not secure so refuse it
+        let tls_channel_binding = request
+            .tls_channel_binding
+            .context("SSH auth requires TLS (no channel binding)")?;
+        let signed_parts =
+            SignedParts::new(method, path, nonce, request.headers, tls_channel_binding);
 
         // clone the keys to drop the authorized_keys.lock() ASAP and avoid it being
         // held during the (slow) verify()

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -8,7 +8,9 @@ use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
 use crate::{AuthRequest, Authenticator};
-use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding};
+use varlink_http_bridge::{
+    SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding, sshauth_accept_value,
+};
 
 /// One tracked `authorized_keys` file: its mtime when last read and the
 /// (fingerprint -> key) map of supported keys it contained. Bundling
@@ -453,6 +455,13 @@ impl Authenticator for SshKeyAuthenticator {
         let nonce =
             extract_nonce(request.headers).context("missing nonce header (x-auth-nonce)")?;
         let nonce = nonce.as_str();
+        let accept = sshauth_accept_value(
+            request
+                .headers
+                .get_all(axum::http::header::ACCEPT)
+                .iter()
+                .map(axum::http::HeaderValue::as_bytes),
+        );
 
         let unverified_token =
             sshauth::UnverifiedToken::try_from(token_str).context("invalid token")?;
@@ -470,6 +479,7 @@ impl Authenticator for SshKeyAuthenticator {
             .max_skew_seconds(self.max_skew)
             .action("method", method)
             .action("path", path)
+            .action("accept", &accept)
             .action("nonce", nonce)
             .action(
                 "tls-channel-binding",

--- a/src/bin/varlink-httpd/auth_ssh.rs
+++ b/src/bin/varlink-httpd/auth_ssh.rs
@@ -8,9 +8,7 @@ use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 
 use crate::{AuthRequest, Authenticator};
-use varlink_http_bridge::{
-    SSHAUTH_MAGIC_PREFIX, SSHAUTH_NONCE_HEADER, TlsChannelBinding, sshauth_accept_value,
-};
+use varlink_http_bridge::sshauth_token::{SSHAUTH_NONCE_HEADER, SignedParts, UnverifiedToken};
 
 /// One tracked `authorized_keys` file: its mtime when last read and the
 /// (fingerprint -> key) map of supported keys it contained. Bundling
@@ -455,44 +453,24 @@ impl Authenticator for SshKeyAuthenticator {
         let nonce =
             extract_nonce(request.headers).context("missing nonce header (x-auth-nonce)")?;
         let nonce = nonce.as_str();
-        let accept = sshauth_accept_value(
-            request
-                .headers
-                .get_all(axum::http::header::ACCEPT)
-                .iter()
-                .map(axum::http::HeaderValue::as_bytes),
+        let signed_parts = SignedParts::new(
+            method,
+            path,
+            nonce,
+            request.headers,
+            request.tls_channel_binding,
         );
 
-        let unverified_token =
-            sshauth::UnverifiedToken::try_from(token_str).context("invalid token")?;
+        let unverified_token = UnverifiedToken::try_from(token_str).context("invalid token")?;
 
         // clone the keys to drop the authorized_keys.lock() ASAP and avoid it being
-        // held during the (slow) verify_for()
+        // held during the (slow) verify()
         let authorized_keys: Vec<ssh_key::PublicKey> = {
             let ak = self.authorized_keys.lock().unwrap();
             ak.all_keys()
         };
 
-        let verified = unverified_token
-            .verify_for()
-            .magic_prefix(SSHAUTH_MAGIC_PREFIX)
-            .max_skew_seconds(self.max_skew)
-            .action("method", method)
-            .action("path", path)
-            .action("accept", &accept)
-            .action("nonce", nonce)
-            .action(
-                "tls-channel-binding",
-                // Safe: when TLS is active the server always provides a real binding
-                // (TLS 1.3 enforced in load_tls_acceptor), so a token signed with ""
-                // will fail verification. The "" default only applies to non-TLS
-                // connections where channel binding is not relevant.
-                request
-                    .tls_channel_binding
-                    .map_or("", TlsChannelBinding::as_str),
-            )
-            .with_keys(&authorized_keys)
-            .context("token verification failed")?;
+        let verified = signed_parts.verify(&unverified_token, self.max_skew, &authorized_keys)?;
 
         // good signature, check that nonce is unique
         self.nonces

--- a/src/bin/varlink-httpd/main.rs
+++ b/src/bin/varlink-httpd/main.rs
@@ -1029,6 +1029,14 @@ fn varlink_call_to_jsonseq(
         .unwrap()
 }
 
+fn wants_json_seq(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get_all(axum::http::header::ACCEPT)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|v| v.contains("application/json-seq"))
+}
+
 /// Call a varlink method on the given socket.
 ///
 /// - Default: single JSON response via varlink `call`
@@ -1042,11 +1050,6 @@ async fn call_varlink_method(
     headers: &axum::http::HeaderMap,
     call_args: &HashMap<String, Value>,
 ) -> Result<Response, AppError> {
-    let accept = headers
-        .get(axum::http::header::ACCEPT)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or_default();
-
     let method_call = DynMethod {
         method,
         parameters: Some(call_args),
@@ -1054,7 +1057,7 @@ async fn call_varlink_method(
 
     let conn_arc = get_varlink_connection(socket, state, conn_cache).await?;
     let mut connection = conn_arc.lock_owned().await;
-    if accept.contains("application/json-seq") {
+    if wants_json_seq(headers) {
         connection
             .send_call(&zlink::Call::new(&method_call).set_more(true), vec![])
             .await?;

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -2285,7 +2285,7 @@ mod sshauth_tests {
                 Request::get("/sockets")
                     .header("Authorization", "Bearer bogus-token")
                     .header(
-                        varlink_http_bridge::SSHAUTH_NONCE_HEADER,
+                        varlink_http_bridge::sshauth_token::SSHAUTH_NONCE_HEADER,
                         "a-nonce-long-enough-1234",
                     )
                     .body(Body::empty())

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -1959,6 +1959,30 @@ fn test_build_authenticators_ssh_without_keys_rejects() {
     assert!(check_request(auths[0].as_ref(), "GET", "/health", None, None, None).is_err());
 }
 
+/// `Accept` may arrive split over several field lines; the `more` request
+/// must be seen in any of them, not just the first.
+#[test]
+fn test_wants_json_seq_across_field_lines() {
+    fn headers(accept: &[&str]) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        for value in accept {
+            headers.append(axum::http::header::ACCEPT, value.parse().unwrap());
+        }
+        headers
+    }
+
+    assert!(!crate::wants_json_seq(&headers(&[])));
+    assert!(!crate::wants_json_seq(&headers(&["application/json"])));
+    assert!(crate::wants_json_seq(&headers(&["application/json-seq"])));
+    assert!(crate::wants_json_seq(&headers(&[
+        "application/json, application/json-seq"
+    ])));
+    assert!(crate::wants_json_seq(&headers(&[
+        "application/json",
+        "application/json-seq"
+    ])));
+}
+
 // --- SSH key auth tests ---
 
 #[cfg(feature = "sshauth")]
@@ -2115,6 +2139,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce);
         let token = tb.sign().await.unwrap();
 
@@ -2140,6 +2165,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce);
         let token = tb.sign().await.unwrap();
 
@@ -2165,6 +2191,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce)
             .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
@@ -2179,6 +2206,55 @@ mod sshauth_tests {
             Some(&cb),
         )
         .expect("valid ed25519 token should pass");
+    }
+
+    #[tokio::test]
+    async fn test_ssh_auth_accept_header_is_signed() {
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+
+        let sign = async |nonce: &str, accept: &str| {
+            let mut tb = signer.sign_for();
+            tb.action("method", "GET")
+                .action("path", "/sockets")
+                .action("accept", accept)
+                .action("nonce", nonce)
+                .action("tls-channel-binding", cb.as_str());
+            format!("Bearer {}", tb.sign().await.unwrap().encode())
+        };
+        let check = |header: &str, nonce: &str, accept: Option<&str>| {
+            let mut headers = axum::http::HeaderMap::new();
+            headers.insert("authorization", header.parse().unwrap());
+            headers.insert("x-auth-nonce", nonce.parse().unwrap());
+            if let Some(a) = accept {
+                headers.insert("accept", a.parse().unwrap());
+            }
+            auth.check_request(&AuthRequest {
+                method: "GET",
+                path: "/sockets",
+                headers: &headers,
+                tls_channel_binding: Some(&cb),
+            })
+        };
+
+        let nonce = "accept-signed-match-1234";
+        let header = sign(nonce, "application/json-seq").await;
+        check(&header, nonce, Some("application/json-seq")).expect("matching Accept should pass");
+
+        let nonce = "accept-signed-stripped-12";
+        let header = sign(nonce, "application/json-seq").await;
+        assert!(
+            check(&header, nonce, None).is_err(),
+            "a stripped Accept header must be rejected"
+        );
+
+        let nonce = "accept-signed-added-1234";
+        let header = sign(nonce, "").await;
+        assert!(
+            check(&header, nonce, Some("application/json-seq")).is_err(),
+            "an added Accept header must be rejected"
+        );
     }
 
     #[tokio::test]
@@ -2324,6 +2400,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce)
             .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
@@ -2365,7 +2442,9 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let mut tb = signer.sign_for();
-        tb.action("method", "GET").action("path", "/sockets");
+        tb.action("method", "GET")
+            .action("path", "/sockets")
+            .action("accept", "");
         let token = tb.sign().await.unwrap();
         let header = format!("Bearer {}", token.encode());
 
@@ -2387,6 +2466,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce)
             .action("tls-channel-binding", cb_signer);
         let token = tb.sign().await.unwrap();
@@ -2417,6 +2497,7 @@ mod sshauth_tests {
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
+            .action("accept", "")
             .action("nonce", nonce)
             .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();

--- a/src/bin/varlink-httpd/tests.rs
+++ b/src/bin/varlink-httpd/tests.rs
@@ -2136,18 +2136,27 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path);
 
         let nonce = "test-nonce-expired12345";
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
             .action("accept", "")
-            .action("nonce", nonce);
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
 
         // Wait for the token to become stale (max_skew is 0)
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         let header = format!("Bearer {}", token.encode());
-        let result = check_request(&auth, "GET", "/sockets", Some(&header), Some(nonce), None);
+        let result = check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        );
         assert!(result.is_err(), "expired token should be rejected");
     }
 
@@ -2162,15 +2171,24 @@ mod sshauth_tests {
         let signer = make_test_token_signer(&key_path_b);
 
         let nonce = "test-nonce-unknown-fp12345";
+        let cb = TlsChannelBinding::new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
             .action("accept", "")
-            .action("nonce", nonce);
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb.as_str());
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = check_request(&auth, "GET", "/sockets", Some(&header), Some(nonce), None);
+        let result = check_request(
+            &auth,
+            "GET",
+            "/sockets",
+            Some(&header),
+            Some(nonce),
+            Some(&cb),
+        );
         assert!(result.is_err());
         assert!(
             result
@@ -2254,6 +2272,33 @@ mod sshauth_tests {
         assert!(
             check(&header, nonce, Some("application/json-seq")).is_err(),
             "an added Accept header must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ssh_auth_rejects_without_tls() {
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
+
+        let nonce = "no-tls-binding-test-1234";
+        let mut tb = signer.sign_for();
+        tb.action("method", "GET")
+            .action("path", "/sockets")
+            .action("accept", "")
+            .action("nonce", nonce)
+            .action("tls-channel-binding", "");
+        let token = tb.sign().await.unwrap();
+        let header = format!("Bearer {}", token.encode());
+
+        // a request without a channel binding can only come in over plain
+        // HTTP, which --auth=ssh refuses at startup: fail closed
+        let result = check_request(&auth, "GET", "/sockets", Some(&header), Some(nonce), None);
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("SSH auth requires TLS"),
+            "request without TLS binding must be rejected"
         );
     }
 

--- a/src/bin/varlinkctl-http/main.rs
+++ b/src/bin/varlinkctl-http/main.rs
@@ -409,6 +409,19 @@ fn resp_body_text(resp: &tungstenite::http::Response<Option<Vec<u8>>>) -> Option
         .map(|b| String::from_utf8_lossy(b).into_owned())
 }
 
+/// Whether `url` selects a TLS transport, mirroring the scheme handling
+/// in [`connect_transport`] and [`connect_tcp`].
+///
+/// Schemes are case-insensitive (RFC 3986 section 3.1), so `HTTPS://` has
+/// to count as TLS here too.
+/// <https://www.rfc-editor.org/rfc/rfc3986#section-3.1>
+fn url_is_tls(url: &str) -> bool {
+    let scheme = url.split_once("://").map_or("", |(scheme, _)| scheme);
+    ["https", "wss", "vsock+tls"]
+        .iter()
+        .any(|tls_scheme| scheme.eq_ignore_ascii_case(tls_scheme))
+}
+
 /// The TLS channel binding is returned so auth headers can be signed
 /// over it before the WebSocket upgrade.
 async fn connect_transport(
@@ -1003,6 +1016,27 @@ mod tests {
     #[cfg(feature = "sshauth")]
     mod sshauth {
         use super::*;
+
+        #[test]
+        fn test_url_is_tls_ignores_scheme_case() {
+            for url in [
+                "https://h/",
+                "HTTPS://h/",
+                "WsS://h/",
+                "VSOCK+TLS://2:1031/",
+            ] {
+                assert!(url_is_tls(url), "{url}");
+            }
+            for url in [
+                "http://h/",
+                "HTTP://h/",
+                "ws://h/",
+                "vsock://2:1031/",
+                "h:1031",
+            ] {
+                assert!(!url_is_tls(url), "{url}");
+            }
+        }
 
         /// Wraps the handshake error the same way `ws_upgrade` does.
         async fn handshake_error(response: &'static str) -> anyhow::Error {

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -63,7 +63,7 @@ impl fmt::Display for SshKey {
 async fn add_auth_headers(
     request: &mut tungstenite::http::Request<()>,
     key: &SshKey,
-    tls_channel_binding: Option<&TlsChannelBinding>,
+    tls_channel_binding: &TlsChannelBinding,
 ) -> Result<()> {
     // to_string: ends the borrow of `request` before headers_mut() below
     let path_and_query = request
@@ -119,6 +119,14 @@ impl ClientAuth for SshSignature {
 /// failed to sign), one unauthenticated attempt is made and the
 /// server decides whether to allow that.
 async fn connect_with_ssh_retry(url: &str) -> Result<Option<crate::Ws>> {
+    if !crate::url_is_tls(url) {
+        if SshSignature.configured() {
+            bail!("VARLINK_SSH_KEY is set but {url} is not TLS, SSH auth needs TLS");
+        }
+        debug!("plain transport, not offering SSH auth");
+        return Ok(None);
+    }
+
     let keys = list_ssh_keys().await?;
     if keys.is_empty() {
         return Ok(None);
@@ -126,9 +134,12 @@ async fn connect_with_ssh_retry(url: &str) -> Result<Option<crate::Ws>> {
     let ws = try_each_key(&keys, async |key| {
         let (stream, mut request, tcb) = crate::connect_transport(url).await?;
         if let Some(key) = key {
-            add_auth_headers(&mut request, key, tcb.as_ref()).await?;
+            let tcb = tcb
+                .as_ref()
+                .context("TLS connection without channel binding")?;
+            add_auth_headers(&mut request, key, tcb).await?;
         }
-        crate::ws_upgrade(request, stream, tcb.is_some()).await
+        crate::ws_upgrade(request, stream, true).await
     })
     .await?;
     Ok(Some(ws))

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use futures_util::future::LocalBoxFuture;
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
-use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding};
+use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding, sshauth_accept_value};
 
 use crate::client_auth::ClientAuth;
 
@@ -69,9 +69,18 @@ async fn add_auth_headers(
         .map_or(request.uri().path(), |pq| pq.as_str())
         .to_string();
 
-    let (auth_header, nonce) = sign_with_key(key, "GET", &path_and_query, tls_channel_binding)
-        .await
-        .context(SigningFailed)?;
+    let accept = sshauth_accept_value(
+        request
+            .headers()
+            .get_all(tungstenite::http::header::ACCEPT)
+            .iter()
+            .map(tungstenite::http::HeaderValue::as_bytes),
+    );
+
+    let (auth_header, nonce) =
+        sign_with_key(key, "GET", &path_and_query, &accept, tls_channel_binding)
+            .await
+            .context(SigningFailed)?;
 
     request.headers_mut().insert(
         "Authorization",
@@ -252,13 +261,14 @@ async fn list_ssh_keys() -> Result<Vec<SshKey>> {
     Ok(vec![])
 }
 
-/// Sign the request parameters (method, path, nonce, TLS channel binding)
-/// with the given key.  Returns the `Authorization` header value carrying
-/// the signed sshauth token, and the nonce.
+/// Sign the request parameters (method, path, accept, nonce, TLS channel
+/// binding) with the given key.  Returns the `Authorization` header value
+/// carrying the signed sshauth token, and the nonce.
 async fn sign_with_key(
     key: &SshKey,
     method: &str,
     path_and_query: &str,
+    accept: &str,
     tls_channel_binding: Option<&TlsChannelBinding>,
 ) -> Result<(String, String)> {
     let nonce = generate_nonce();
@@ -283,6 +293,7 @@ async fn sign_with_key(
     let mut tb = signer.sign_for();
     tb.action("method", method)
         .action("path", path_and_query)
+        .action("accept", accept)
         .action("nonce", &nonce)
         .action(
             "tls-channel-binding",

--- a/src/bin/varlinkctl-http/sshauth_client.rs
+++ b/src/bin/varlinkctl-http/sshauth_client.rs
@@ -6,7 +6,10 @@ use anyhow::{Context, Result, bail};
 use futures_util::future::LocalBoxFuture;
 use log::{debug, warn};
 use tokio_tungstenite::tungstenite;
-use varlink_http_bridge::{SSHAUTH_MAGIC_PREFIX, TlsChannelBinding, sshauth_accept_value};
+use varlink_http_bridge::TlsChannelBinding;
+use varlink_http_bridge::sshauth_token::{
+    SSHAUTH_NONCE_HEADER, SignedParts, signer_from_agent, signer_from_private_key,
+};
 
 use crate::client_auth::ClientAuth;
 
@@ -68,26 +71,26 @@ async fn add_auth_headers(
         .path_and_query()
         .map_or(request.uri().path(), |pq| pq.as_str())
         .to_string();
+    let nonce = generate_nonce();
 
-    let accept = sshauth_accept_value(
-        request
-            .headers()
-            .get_all(tungstenite::http::header::ACCEPT)
-            .iter()
-            .map(tungstenite::http::HeaderValue::as_bytes),
+    let signer = signer_for_key(key).context(SigningFailed)?;
+    let signed_parts = SignedParts::new(
+        "GET",
+        &path_and_query,
+        &nonce,
+        request.headers(),
+        tls_channel_binding,
     );
-
-    let (auth_header, nonce) =
-        sign_with_key(key, "GET", &path_and_query, &accept, tls_channel_binding)
-            .await
-            .context(SigningFailed)?;
+    let token = signed_parts.sign(&signer).await.context(SigningFailed)?;
 
     request.headers_mut().insert(
         "Authorization",
-        auth_header.parse().context("invalid auth header value")?,
+        format!("Bearer {token}")
+            .parse()
+            .context("invalid auth header value")?,
     );
     request.headers_mut().insert(
-        varlink_http_bridge::SSHAUTH_NONCE_HEADER,
+        SSHAUTH_NONCE_HEADER,
         nonce.parse().context("invalid nonce header value")?,
     );
     Ok(())
@@ -261,47 +264,14 @@ async fn list_ssh_keys() -> Result<Vec<SshKey>> {
     Ok(vec![])
 }
 
-/// Sign the request parameters (method, path, accept, nonce, TLS channel
-/// binding) with the given key.  Returns the `Authorization` header value
-/// carrying the signed sshauth token, and the nonce.
-async fn sign_with_key(
-    key: &SshKey,
-    method: &str,
-    path_and_query: &str,
-    accept: &str,
-    tls_channel_binding: Option<&TlsChannelBinding>,
-) -> Result<(String, String)> {
-    let nonce = generate_nonce();
-
-    let mut signer_builder = match key {
-        SshKey::PrivateKey { key, .. } => {
-            sshauth::TokenSigner::using_private_key(key.as_ref().clone())?
-        }
-        SshKey::AgentKey { auth_sock, key } => {
-            let mut sb = sshauth::TokenSigner::using_authsock(auth_sock)?;
-            sb.key(key.clone());
-            sb
-        }
-    };
+/// A token signer for `key`, either from the private key on disk or via
+/// the ssh-agent.
+fn signer_for_key(key: &SshKey) -> Result<sshauth::TokenSigner> {
     debug!("SSH auth: using {key}");
-
-    signer_builder
-        .include_fingerprint(true)
-        .magic_prefix(SSHAUTH_MAGIC_PREFIX);
-    let signer = signer_builder.build()?;
-
-    let mut tb = signer.sign_for();
-    tb.action("method", method)
-        .action("path", path_and_query)
-        .action("accept", accept)
-        .action("nonce", &nonce)
-        .action(
-            "tls-channel-binding",
-            tls_channel_binding.map_or("", TlsChannelBinding::as_str),
-        );
-    let token: sshauth::token::Token = tb.sign().await?;
-
-    Ok((format!("Bearer {}", token.encode()), nonce))
+    match key {
+        SshKey::PrivateKey { key, .. } => signer_from_private_key(key.as_ref().clone()),
+        SshKey::AgentKey { auth_sock, key } => signer_from_agent(auth_sock, key.clone()),
+    }
 }
 
 fn generate_nonce() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,18 @@ pub const SSHAUTH_MAGIC_PREFIX: [u8; 8] = *b"vhbridge";
 /// token payload to prevent replay attacks.
 pub const SSHAUTH_NONCE_HEADER: &str = "x-auth-nonce";
 
+#[cfg(feature = "sshauth")]
+/// The `Accept` header as it enters the signed token: all values joined as
+/// one list, "" when absent. It selects the varlink `more` flag, so client
+/// and server must agree on one canonical form.
+pub fn sshauth_accept_value<'a>(values: impl IntoIterator<Item = &'a [u8]>) -> String {
+    values
+        .into_iter()
+        .map(String::from_utf8_lossy)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Default port for the HTTP bridge when listening on or connecting via vsock.
 pub const DEFAULT_PORT: u32 = 1031;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#[cfg(feature = "sshauth")]
+pub mod sshauth_token;
 pub mod sysconf;
-
-#[cfg(feature = "sshauth")]
-/// Namespace prefix for SSH-based authentication tokens, analogous to
-/// `ssh-keygen -Y sign -n <namespace>`.  Binds signatures to this application
-/// so they cannot be replayed against other services.
-pub const SSHAUTH_MAGIC_PREFIX: [u8; 8] = *b"vhbridge";
-
-#[cfg(feature = "sshauth")]
-/// HTTP header carrying the random nonce that is included in the signed
-/// token payload to prevent replay attacks.
-pub const SSHAUTH_NONCE_HEADER: &str = "x-auth-nonce";
-
-#[cfg(feature = "sshauth")]
-/// The `Accept` header as it enters the signed token: all values joined as
-/// one list, "" when absent. It selects the varlink `more` flag, so client
-/// and server must agree on one canonical form.
-pub fn sshauth_accept_value<'a>(values: impl IntoIterator<Item = &'a [u8]>) -> String {
-    values
-        .into_iter()
-        .map(String::from_utf8_lossy)
-        .collect::<Vec<_>>()
-        .join(", ")
-}
 
 /// Default port for the HTTP bridge when listening on or connecting via vsock.
 pub const DEFAULT_PORT: u32 = 1031;

--- a/src/sshauth_token.rs
+++ b/src/sshauth_token.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+//! The sshauth token format shared by varlink-httpd and varlinkctl-http.
+//! Everything that determines whether a signature verifies lives here so
+//! the signing and verifying sides cannot drift apart.
+
+use anyhow::{Context, Result};
+use http::HeaderMap;
+pub use sshauth::UnverifiedToken;
+use sshauth::signer::TokenSignerBuilder;
+use sshauth::{PrivateKey, PublicKey, TokenSigner, VerifiedToken};
+
+use crate::TlsChannelBinding;
+
+/// Namespace prefix for SSH-based authentication tokens, analogous to
+/// `ssh-keygen -Y sign -n <namespace>`.  Binds signatures to this application
+/// so they cannot be replayed against other services.
+const SSHAUTH_MAGIC_PREFIX: [u8; 8] = *b"vhbridge";
+
+/// HTTP header carrying the random nonce that is included in the signed
+/// token payload to prevent replay attacks.
+pub const SSHAUTH_NONCE_HEADER: &str = "x-auth-nonce";
+
+/// A signer for a private key held in memory.
+///
+/// # Errors
+/// Returns an error if the key algorithm is not supported for signing.
+pub fn signer_from_private_key(key: PrivateKey) -> Result<TokenSigner> {
+    signer_for(TokenSigner::using_private_key(key)?)
+}
+
+/// A signer that delegates to the ssh-agent at `auth_sock` for `key`.
+///
+/// # Errors
+/// Returns an error if the agent socket cannot be used.
+pub fn signer_from_agent(auth_sock: &str, key: PublicKey) -> Result<TokenSigner> {
+    let mut builder = TokenSigner::using_authsock(auth_sock)?;
+    builder.key(key);
+    signer_for(builder)
+}
+
+fn signer_for(mut builder: TokenSignerBuilder) -> Result<TokenSigner> {
+    builder
+        .include_fingerprint(true)
+        .magic_prefix(SSHAUTH_MAGIC_PREFIX);
+    builder.build()
+}
+
+fn accept_header_value(headers: &HeaderMap) -> String {
+    headers
+        .get_all(http::header::ACCEPT)
+        .iter()
+        .map(|v| String::from_utf8_lossy(v.as_bytes()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The parts of the request covered by the signature.
+pub struct SignedParts<'a> {
+    method: &'a str,
+    path_and_query: &'a str,
+    accept: String,
+    nonce: &'a str,
+    tls_channel_binding: Option<&'a TlsChannelBinding>,
+}
+
+impl<'a> SignedParts<'a> {
+    #[must_use]
+    pub fn new(
+        method: &'a str,
+        path_and_query: &'a str,
+        nonce: &'a str,
+        headers: &HeaderMap,
+        tls_channel_binding: Option<&'a TlsChannelBinding>,
+    ) -> Self {
+        Self {
+            method,
+            path_and_query,
+            accept: accept_header_value(headers),
+            nonce,
+            tls_channel_binding,
+        }
+    }
+
+    /// Return the encoded token for the `Authorization: Bearer` header.
+    ///
+    /// # Errors
+    /// Returns an error if the key or the agent refuses to sign.
+    pub async fn sign(&self, signer: &TokenSigner) -> Result<String> {
+        let mut tb = signer.sign_for();
+        tb.actions(self.actions());
+        Ok(tb.sign().await?.encode())
+    }
+
+    /// Check a token against `keys`.
+    ///
+    /// # Errors
+    /// Returns an error if the token is malformed, too old, not signed
+    /// over these parts, or signed by a key that is not in `keys`.
+    pub fn verify(
+        &self,
+        token: &UnverifiedToken,
+        max_skew_seconds: u64,
+        keys: &[PublicKey],
+    ) -> Result<VerifiedToken> {
+        token
+            .verify_for()
+            .magic_prefix(SSHAUTH_MAGIC_PREFIX)
+            .max_skew_seconds(max_skew_seconds)
+            .actions(self.actions())
+            .with_keys(keys)
+            .context("token verification failed")
+    }
+
+    fn actions(&self) -> [(&'static str, &str); 5] {
+        [
+            ("method", self.method),
+            ("path", self.path_and_query),
+            ("accept", &self.accept),
+            ("nonce", self.nonce),
+            (
+                "tls-channel-binding",
+                // only non-TLS can be "", with TLS this is always set
+                self.tls_channel_binding
+                    .map_or("", TlsChannelBinding::as_str),
+            ),
+        ]
+    }
+}

--- a/src/sshauth_token.rs
+++ b/src/sshauth_token.rs
@@ -61,7 +61,7 @@ pub struct SignedParts<'a> {
     path_and_query: &'a str,
     accept: String,
     nonce: &'a str,
-    tls_channel_binding: Option<&'a TlsChannelBinding>,
+    tls_channel_binding: &'a TlsChannelBinding,
 }
 
 impl<'a> SignedParts<'a> {
@@ -71,7 +71,7 @@ impl<'a> SignedParts<'a> {
         path_and_query: &'a str,
         nonce: &'a str,
         headers: &HeaderMap,
-        tls_channel_binding: Option<&'a TlsChannelBinding>,
+        tls_channel_binding: &'a TlsChannelBinding,
     ) -> Self {
         Self {
             method,
@@ -118,12 +118,7 @@ impl<'a> SignedParts<'a> {
             ("path", self.path_and_query),
             ("accept", &self.accept),
             ("nonce", self.nonce),
-            (
-                "tls-channel-binding",
-                // only non-TLS can be "", with TLS this is always set
-                self.tls_channel_binding
-                    .map_or("", TlsChannelBinding::as_str),
-            ),
+            ("tls-channel-binding", self.tls_channel_binding.as_str()),
         ]
     }
 }


### PR DESCRIPTION
This includes #124 - while working on adding the Accept header I noticed that the code become a bit unstructed so this attempts to make it nicer.

---

sshauth: require a `tls_channel_binding`

For historic reasons the TLS channel binding was optional in sshauth
and an empty string was signed in its place. Since `--auth=ssh`
refuses to start with `--insecure`, a verifying server always has
TLS and thus a binding, so the placeholder only papered over a case
that must not happen.

So make the binding mandatory in `sshauth_token::SignedParts`.


---

The sshauth code was a bit unstructed, the client and server
side where too far apart even though they need to be fundamentaly
the same shape. So this commit extract common helpers into the
sshauth_token module (removing sshauth untidiness from lib.rs)
and also extracts a `sshauth_token::SignedParts` struct that
does the sign/verify work in a single place.

The protocol details are now all in sshauth_token and private
which means a single place to edit and much less risk of drift.

---

sshauth: sign the `Accept` header as well

So far sshauth was not signing the `Accept:` header. This
header (implicitly) carries the `more` flag so it makes
sense to sign it as well.

This commit will break compatibility with existing deployments.
There is no official release yet so at this point this should
be fine but its an inconvenience.

Thanks to @Skyb0rg007 for suggesting this.

Closes: https://github.com/systemd/varlink-http-bridge/issues/119

